### PR TITLE
[Fix] toss api 요청할 수 있는 요청인지 판단하는 조건문의 조건 수정.

### DIFF
--- a/src/main/java/com/windfall/api/payment/service/PaymentService.java
+++ b/src/main/java/com/windfall/api/payment/service/PaymentService.java
@@ -108,8 +108,6 @@ public class PaymentService {
           .finalPrice(amount)
           .build();
       tradeRepository.save(trade); // 신규 엔티티만 save
-    } else {
-      trade.changeBuyer(buyerId);
     }
 
     final Trade tradeFixed = trade;
@@ -117,11 +115,10 @@ public class PaymentService {
     // 경우 1. buyer가 본인: 본인이 1빠따. 상태 체크 필요 X
     // 경우 2. buyer가 남: trade 상태가 CANCELED나 FAILED일 때만 가능.
     if (!trade.getBuyerId().equals(buyerId)
-        && (trade.getStatus() == TradeStatus.PAYMENT_CANCELED
-        || trade.getStatus() == TradeStatus.PAYMENT_FAILED)) {
+        && (trade.getStatus() != TradeStatus.PAYMENT_CANCELED
+        && trade.getStatus() != TradeStatus.PAYMENT_FAILED)) {
       throw new ErrorException(ErrorCode.PAYMENT_REQUEST_LATE);
     }
-
 
     TossPaymentConfirmRequest tossRequest = new TossPaymentConfirmRequest(paymentKey, orderId,
         amount);

--- a/src/main/java/com/windfall/api/payment/service/PaymentService.java
+++ b/src/main/java/com/windfall/api/payment/service/PaymentService.java
@@ -1,14 +1,11 @@
 package com.windfall.api.payment.service;
 
-import com.windfall.api.auction.service.AuctionStateService;
 import com.windfall.api.payment.dto.request.PaymentConfirmRequest;
 import com.windfall.api.payment.dto.request.TossPaymentConfirmRequest;
 import com.windfall.api.payment.dto.response.PaymentConfirmResponse;
 import com.windfall.api.payment.dto.response.TossPaymentConfirmResponse;
 import com.windfall.domain.auction.entity.Auction;
 import com.windfall.domain.auction.repository.AuctionRepository;
-import com.windfall.domain.chat.repository.ChatRoomRepository;
-import com.windfall.domain.payment.repository.PaymentRepository;
 import com.windfall.domain.trade.entity.Trade;
 import com.windfall.domain.trade.enums.TradeStatus;
 import com.windfall.domain.trade.repository.TradeRepository;
@@ -32,12 +29,9 @@ import reactor.core.publisher.Mono;
 @RequiredArgsConstructor
 public class PaymentService {
   private final WebClient webClient;
-  private final PaymentRepository paymentRepository;
   private final AuctionRepository auctionRepository;
   private final TradeRepository tradeRepository;
-  private final ChatRoomRepository chatRoomRepository;
   private final UserRepository userRepository;
-  private final AuctionStateService auctionStateService;
   private final PaymentPostProcessService paymentPostProcessService;
 
   @Value("${spring.toss.secretkey}")
@@ -111,14 +105,9 @@ public class PaymentService {
     }
 
     final Trade tradeFixed = trade;
-
-    // 경우 1. buyer가 본인: 본인이 1빠따. 상태 체크 필요 X
-    // 경우 2. buyer가 남: trade 상태가 CANCELED나 FAILED일 때만 가능.
-    if (!trade.getBuyerId().equals(buyerId)
-        && (trade.getStatus() != TradeStatus.PAYMENT_CANCELED
-        && trade.getStatus() != TradeStatus.PAYMENT_FAILED)) {
-      throw new ErrorException(ErrorCode.PAYMENT_REQUEST_LATE);
-    }
+    
+    // toss api proceed해도 되는지 검증
+    validatePaymentRequest(buyerId, trade.getStatus(), trade.getBuyerId());
 
     TossPaymentConfirmRequest tossRequest = new TossPaymentConfirmRequest(paymentKey, orderId,
         amount);
@@ -188,4 +177,25 @@ public class PaymentService {
     return new PaymentConfirmResponse(
         tossResponse.orderId(), tossResponse.paymentKey(), tossResponse.totalAmount());
   }
+
+  // toss api proceed해도 되는지 검증용 함수
+  public void validatePaymentRequest(Long tradeBuyerId, TradeStatus status, Long requestBuyerId) {
+
+    boolean isSameBuyer = tradeBuyerId.equals(requestBuyerId);
+    boolean isRetryable =
+        status == TradeStatus.PAYMENT_CANCELED
+            || status == TradeStatus.PAYMENT_FAILED;
+
+    if (isSameBuyer) {
+      if (status != TradeStatus.PENDING) {
+        throw new ErrorException(ErrorCode.INVALID_TRADE_INIT);
+      }
+    } else {
+      if (!isRetryable) {
+        throw new ErrorException(ErrorCode.PAYMENT_REQUEST_LATE);
+      }
+    }
+  }
+
+
 }

--- a/src/main/java/com/windfall/global/exception/ErrorCode.java
+++ b/src/main/java/com/windfall/global/exception/ErrorCode.java
@@ -63,6 +63,7 @@ public enum ErrorCode {
   INVALID_PAYMENT_PROVIDER(HttpStatus.BAD_REQUEST, "결제 제공사를 선택하지 않았습니다."),
   INVALID_PAYMENT_METHOD(HttpStatus.BAD_REQUEST, "결제 수단을 선택하지 않았습니다."),
   INVALID_PAYMENT_TOSS_URL(HttpStatus.INTERNAL_SERVER_ERROR, "서버 속 토스 결제 승인 URL 설정에 오류가 있습니다."),
+  INVALID_TRADE_INIT(HttpStatus.INTERNAL_SERVER_ERROR, "최초 요청임에도 서버에서 해당 거래 초기화를 잘못해서 실패했습니다."),
   PAYMENT_CONFIRM_FAILED(HttpStatus.BAD_REQUEST, "토스에서 해당 결제를 찾을 수 없습니다."),
   PAYMENT_ORDER_MISMATCH(HttpStatus.BAD_REQUEST, "주문번호가 일치하지 않는 보안성 에러입니다."),
   PAYMENT_AMOUNT_MISMATCH(HttpStatus.CONFLICT, "주문 가격이 일치하지 않는 보안성 에러입니다."),

--- a/src/test/java/com/windfall/api/payment/service/PaymentServiceValidatePaymentRequestTest.java
+++ b/src/test/java/com/windfall/api/payment/service/PaymentServiceValidatePaymentRequestTest.java
@@ -1,0 +1,90 @@
+package com.windfall.api.payment.service;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import com.windfall.domain.auction.repository.AuctionRepository;
+import com.windfall.domain.trade.enums.TradeStatus;
+import com.windfall.domain.trade.repository.TradeRepository;
+import com.windfall.domain.user.repository.UserRepository;
+import com.windfall.global.exception.ErrorCode;
+import com.windfall.global.exception.ErrorException;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.web.reactive.function.client.WebClient;
+
+@ExtendWith(MockitoExtension.class)
+public class PaymentServiceValidatePaymentRequestTest {
+  @Mock
+  WebClient webClient;
+  @Mock
+  AuctionRepository auctionRepository;
+  @Mock
+  TradeRepository tradeRepository;
+  @Mock
+  UserRepository userRepository;
+  @Mock PaymentPostProcessService paymentPostProcessService;
+
+  @InjectMocks
+  PaymentService service;
+
+  // 1. 본인 + COMPLETED → INVALID_TRADE_INIT
+  @Test
+  void validatePaymentRequest_sameBuyer_completed_should_throw_invalid_trade_init() {
+    ErrorException ex = assertThrows(ErrorException.class, () ->
+        service.validatePaymentRequest(1L, TradeStatus.PAYMENT_COMPLETED, 1L)
+    );
+
+    assertEquals(ErrorCode.INVALID_TRADE_INIT, ex.getErrorCode());
+  }
+
+  // 2. 타인 + FAILED → 통과
+  @Test
+  void validatePaymentRequest_differentBuyer_failed_should_pass() {
+    assertDoesNotThrow(() ->
+        service.validatePaymentRequest(1L, TradeStatus.PAYMENT_FAILED, 2L)
+    );
+  }
+
+  // 3. 타인 + CANCELED → 통과
+  @Test
+  void validatePaymentRequest_differentBuyer_canceled_should_pass() {
+    assertDoesNotThrow(() ->
+        service.validatePaymentRequest(1L, TradeStatus.PAYMENT_CANCELED, 2L)
+    );
+  }
+
+  // 4. 타인 + PENDING → PAYMENT_REQUEST_LATE
+  @Test
+  void validatePaymentRequest_differentBuyer_pending_should_throw_payment_request_late() {
+    ErrorException ex = assertThrows(ErrorException.class, () ->
+        service.validatePaymentRequest(1L, TradeStatus.PENDING, 2L)
+    );
+
+    assertEquals(ErrorCode.PAYMENT_REQUEST_LATE, ex.getErrorCode());
+  }
+
+  // 5. 타인 + COMPLETED → PAYMENT_REQUEST_LATE
+  @Test
+  void validatePaymentRequest_differentBuyer_completed_should_throw_payment_request_late() {
+    ErrorException ex = assertThrows(ErrorException.class, () ->
+        service.validatePaymentRequest(1L, TradeStatus.PAYMENT_COMPLETED, 2L)
+    );
+
+    assertEquals(ErrorCode.PAYMENT_REQUEST_LATE, ex.getErrorCode());
+  }
+
+  // 6. 타인 + PURCHASE_CONFIRMED → PAYMENT_REQUEST_LATE
+  @Test
+  void validatePaymentRequest_differentBuyer_purchase_confirmed_should_throw_payment_request_late() {
+    ErrorException ex = assertThrows(ErrorException.class, () ->
+        service.validatePaymentRequest(1L, TradeStatus.PURCHASE_CONFIRMED, 2L)
+    );
+
+    assertEquals(ErrorCode.PAYMENT_REQUEST_LATE, ex.getErrorCode());
+  }
+}


### PR DESCRIPTION
## 📌 관련 이슈
- close #1 

## 📝 변경 사항
### AS-IS
- toss api 요청 전, 검증 로직이 반대로 되어있음을 발견.

### TO-BE
- 검증 로직 수정.
- 단위테스트 추가.
- 단위테스트를 위해 검증 로직을 함수로 분리.

## 🔍 테스트
- [x] 테스트 코드 작성
- [x] API 테스트
- [ ] 로컬 테스트

## 📸 스크린샷
<img width="1166" height="1033" alt="화면 캡처 2026-04-10 163547" src="https://github.com/user-attachments/assets/fe97f7a7-bb95-4cf7-9fa3-49b66a41fd67" />


## ✅ 체크리스트
- [x] main/develop 브랜치가 아닌 feature 브랜치에서 작성했나요?
- [ ] 코딩 컨벤션을 준수했나요?
- [ ] 불필요한 코드는 제거했나요?
- [x] 주석은 충분히 작성했나요?
- [x] 테스트는 완료했나요?

## 🙋‍♂️ 리뷰어에게
