### PR TITLE
[Fix] 단위테스트 함수 이름 변경.

### DIFF
--- a/src/test/java/com/windfall/api/payment/service/PaymentServiceValidatePaymentRequestTest.java
+++ b/src/test/java/com/windfall/api/payment/service/PaymentServiceValidatePaymentRequestTest.java
@@ -34,7 +34,7 @@ public class PaymentServiceValidatePaymentRequestTest {
 
   // 1. 본인 + COMPLETED → INVALID_TRADE_INIT
   @Test
-  void validatePaymentRequest_sameBuyer_completed_should_throw_invalid_trade_init() {
+  void throws_invalid_trade_init_when_same_buyer_and_not_pending() {
     ErrorException ex = assertThrows(ErrorException.class, () ->
         service.validatePaymentRequest(1L, TradeStatus.PAYMENT_COMPLETED, 1L)
     );
@@ -44,7 +44,7 @@ public class PaymentServiceValidatePaymentRequestTest {
 
   // 2. 타인 + FAILED → 통과
   @Test
-  void validatePaymentRequest_differentBuyer_failed_should_pass() {
+  void does_not_throw_when_other_buyer_and_status_is_failed() {
     assertDoesNotThrow(() ->
         service.validatePaymentRequest(1L, TradeStatus.PAYMENT_FAILED, 2L)
     );
@@ -52,7 +52,7 @@ public class PaymentServiceValidatePaymentRequestTest {
 
   // 3. 타인 + CANCELED → 통과
   @Test
-  void validatePaymentRequest_differentBuyer_canceled_should_pass() {
+  void does_not_throw_when_other_buyer_and_status_is_canceled() {
     assertDoesNotThrow(() ->
         service.validatePaymentRequest(1L, TradeStatus.PAYMENT_CANCELED, 2L)
     );
@@ -60,7 +60,7 @@ public class PaymentServiceValidatePaymentRequestTest {
 
   // 4. 타인 + PENDING → PAYMENT_REQUEST_LATE
   @Test
-  void validatePaymentRequest_differentBuyer_pending_should_throw_payment_request_late() {
+  void throws_payment_request_late_when_other_buyer_and_status_is_not_retryable_pending() {
     ErrorException ex = assertThrows(ErrorException.class, () ->
         service.validatePaymentRequest(1L, TradeStatus.PENDING, 2L)
     );
@@ -70,7 +70,7 @@ public class PaymentServiceValidatePaymentRequestTest {
 
   // 5. 타인 + COMPLETED → PAYMENT_REQUEST_LATE
   @Test
-  void validatePaymentRequest_differentBuyer_completed_should_throw_payment_request_late() {
+  void throws_payment_request_late_when_other_buyer_and_status_is_not_retryable_completed() {
     ErrorException ex = assertThrows(ErrorException.class, () ->
         service.validatePaymentRequest(1L, TradeStatus.PAYMENT_COMPLETED, 2L)
     );
@@ -80,7 +80,7 @@ public class PaymentServiceValidatePaymentRequestTest {
 
   // 6. 타인 + PURCHASE_CONFIRMED → PAYMENT_REQUEST_LATE
   @Test
-  void validatePaymentRequest_differentBuyer_purchase_confirmed_should_throw_payment_request_late() {
+  void throws_payment_request_late_when_other_buyer_and_status_is_not_retryable_purchase_confirmed() {
     ErrorException ex = assertThrows(ErrorException.class, () ->
         service.validatePaymentRequest(1L, TradeStatus.PURCHASE_CONFIRMED, 2L)
     );


### PR DESCRIPTION
## 📌 관련 이슈
- close #3 

## 📝 변경 사항
### AS-IS
- payment 도메인의 PaymentServiceValidatePaymentRequestTest.java 모듈 속 단위 테스트 함수명이 시나리오 테스트스러워 혼동될 여지가 있었습니다.

### TO-BE
- 위 모듈의 함수명을 단위 테스트스럽게 바꿨습니다.

## 🔍 테스트
- [x] 테스트 코드 작성
- [ ] API 테스트
- [ ] 로컬 테스트

## 📸 스크린샷
// 기존처럼 단위테스트 모두 통과합니다.
<img width="872" height="673" alt="image" src="https://github.com/user-attachments/assets/9f4b24d7-3ff1-49a2-bdd9-f0716b1667c3" />


## ✅ 체크리스트
- [ ] main/develop 브랜치가 아닌 feature 브랜치에서 작성했나요?
- [ ] 코딩 컨벤션을 준수했나요?
- [ ] 불필요한 코드는 제거했나요?
- [ ] 주석은 충분히 작성했나요?
- [ ] 테스트는 완료했나요?

## 🙋‍♂️ 리뷰어에게
// 리뷰어가 집중해서 봐야 하는 부분
// 리뷰어에게 요청하고 싶은 사항