### PR TITLE
[Fix] payment api 요청 성공 이후 반환값 정상인지 검증하는 단위테스트.

### DIFF
--- a/src/main/java/com/windfall/api/payment/service/PaymentResponseValidator.java
+++ b/src/main/java/com/windfall/api/payment/service/PaymentResponseValidator.java
@@ -1,0 +1,21 @@
+package com.windfall.api.payment.service;
+
+import com.windfall.api.payment.dto.request.TossPaymentConfirmRequest;
+import com.windfall.api.payment.dto.response.TossPaymentConfirmResponse;
+import com.windfall.global.exception.ErrorCode;
+import com.windfall.global.exception.ErrorException;
+
+public class PaymentResponseValidator {
+
+  public void validate(TossPaymentConfirmResponse response,
+      TossPaymentConfirmRequest request) {
+
+    if (!response.orderId().equals(request.orderId())) {
+      throw new ErrorException(ErrorCode.PAYMENT_ORDER_MISMATCH);
+    }
+
+    if (!response.totalAmount().equals(request.amount())) {
+      throw new ErrorException(ErrorCode.PAYMENT_AMOUNT_MISMATCH);
+    }
+  }
+}

--- a/src/main/java/com/windfall/api/payment/service/PaymentService.java
+++ b/src/main/java/com/windfall/api/payment/service/PaymentService.java
@@ -33,6 +33,7 @@ public class PaymentService {
   private final TradeRepository tradeRepository;
   private final UserRepository userRepository;
   private final PaymentPostProcessService paymentPostProcessService;
+  private final PaymentResponseValidator paymentResponseValidator;
 
   @Value("${spring.toss.secretkey}")
   private String widgetSecretKey;
@@ -161,15 +162,7 @@ public class PaymentService {
         tossResponse.totalAmount()
     );
 
-    if (!tossResponse.orderId().equals(paymentConfirmRequest.orderId())) {
-      trade.changeStatus(TradeStatus.PAYMENT_FAILED);
-      throw new ErrorException(ErrorCode.PAYMENT_ORDER_MISMATCH);
-    }
-
-    if (!tossResponse.totalAmount().equals(paymentConfirmRequest.amount())) {
-      trade.changeStatus(TradeStatus.PAYMENT_FAILED);
-      throw new ErrorException(ErrorCode.PAYMENT_AMOUNT_MISMATCH);
-    }
+    paymentResponseValidator.validate(tossResponse, tossRequest);
 
     // db에 저장하는 로직 따로 뺌.
     paymentPostProcessService.updateDatabaseAfterPayment(auctionId,trade,paymentKey,amount);

--- a/src/test/java/com/windfall/api/payment/service/PaymentServiceValidatePaymentResponseTest.java
+++ b/src/test/java/com/windfall/api/payment/service/PaymentServiceValidatePaymentResponseTest.java
@@ -1,0 +1,68 @@
+package com.windfall.api.payment.service;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+
+import com.windfall.api.payment.dto.request.TossPaymentConfirmRequest;
+import com.windfall.api.payment.dto.response.TossPaymentConfirmResponse;
+import com.windfall.global.exception.ErrorCode;
+import com.windfall.global.exception.ErrorException;
+import org.junit.jupiter.api.Test;
+
+public class PaymentServiceValidatePaymentResponseTest {
+
+
+  PaymentResponseValidator validator = new PaymentResponseValidator();
+
+  @Test
+  void should_pass_when_response_is_valid() {
+    // given
+    TossPaymentConfirmResponse response =
+        new TossPaymentConfirmResponse("Payment-1", "orderId-1", 1000L, "card", "DONE");
+
+    TossPaymentConfirmRequest request =
+        new TossPaymentConfirmRequest("Payment-1", "orderId-1", 1000L);
+
+    // when & then
+    assertDoesNotThrow(() ->
+        validator.validate(response, request)
+    );
+  }
+
+  @Test
+  void should_throw_PAYMENT_ORDER_MISMATCH_when_orderId_differs() {
+    // given
+    TossPaymentConfirmResponse response =
+        new TossPaymentConfirmResponse("Payment-1", "orderId-1", 1000L, "card", "DONE");
+
+    TossPaymentConfirmRequest request =
+        new TossPaymentConfirmRequest("Payment-1", "orderId-2", 1000L);
+
+    // when & then
+    assertThatThrownBy(() ->
+        validator.validate(response, request)
+    )
+        .isInstanceOf(ErrorException.class)
+        .extracting(e -> ((ErrorException)e).getErrorCode())
+        .isEqualTo(ErrorCode.PAYMENT_ORDER_MISMATCH);
+  }
+
+  @Test
+  void should_throw_PAYMENT_AMOUNT_MISMATCH_when_amount_differs() {
+    // given
+    TossPaymentConfirmResponse response =
+        new TossPaymentConfirmResponse("Payment-1", "orderId-1", 1000L, "card", "DONE");
+
+    TossPaymentConfirmRequest request =
+        new TossPaymentConfirmRequest("Payment-1", "orderId-1", 2000L);
+
+    // when & then
+    assertThatThrownBy(() ->
+        validator.validate(response, request)
+    )
+        .isInstanceOf(ErrorException.class)
+        .extracting(e -> ((ErrorException)e).getErrorCode())
+        .isEqualTo(ErrorCode.PAYMENT_AMOUNT_MISMATCH);
+  }
+
+}


### PR DESCRIPTION
- 1. 단위테스트를 위해 서비스 코드에서 검증 코드를 PaymentServiceValidator.java 모듈로 분리.
- 2. PaymentServiceValidatePaymentResponseTest.java에 위 단위테스트 코드 작성.
- 3. 단위 테스트 3개 작성 후 실행. 3개 모두 통과.

## 📌 관련 이슈
- close #5 

## 📝 변경 사항
### AS-IS
- 응답값 단위테스트 코드 부재.
- 응답값 단위테스트를 위한 코드가 서비스 단에 직접 구현됨.

### TO-BE
- 응답값 단위테스트 코드 생성.
- 응답값 단위테스트를 위한 코드를 별도 모듈에 분리.

## 🔍 테스트
- [x] 테스트 코드 작성
- [ ] API 테스트
- [ ] 로컬 테스트

## 📸 스크린샷
// 테스트 3개 모두 성공했습니다.
<img width="859" height="905" alt="image" src="https://github.com/user-attachments/assets/f9809c67-f93b-4124-8b42-a8dfde43954d" />

## ✅ 체크리스트
- [x] main/develop 브랜치가 아닌 feature 브랜치에서 작성했나요?
- [x] 코딩 컨벤션을 준수했나요?
- [ ] 불필요한 코드는 제거했나요?
- [ ] 주석은 충분히 작성했나요?
- [x] 테스트는 완료했나요?

## 🙋‍♂️ 리뷰어에게