### PR TITLE
[Test] payment의 confirm에 대한 레포지토리 테스트

### DIFF
--- a/src/test/java/com/windfall/api/payment/repository/PaymentConfirmRepositoryTest.java
+++ b/src/test/java/com/windfall/api/payment/repository/PaymentConfirmRepositoryTest.java
@@ -165,4 +165,30 @@ class PaymentConfirmRepositoryTest {
     assertNotNull(chatRoom.getId());
     assertEquals(trade.getId(), chatRoom.getTrade().getId());
   }
+
+  @Test
+  void givenAuction_whenFindAuctionById_thenReturnAuction() {
+    User seller = userRepository.save(
+        new User(ProviderType.GOOGLE, "user_id_1",
+            "user_id_1@gmail.com", "nickname_user_id_1",
+            "profile_image_url_user_1")
+    );
+    AuctionCreateRequest request = new AuctionCreateRequest(
+        "test auction",
+        "test description",
+        AuctionCategory.CLOTHING,
+        List.of(),              // tags (optional or empty)
+        List.of(1L, 2L),        // imageIds (필수)
+        1000L,                  // startPrice
+        500L,                   // stopLoss
+        100L,                   // dropAmount
+        LocalDateTime.now().plusHours(1) // startAt (미래 시간 권장)
+    );
+    Auction auction = Auction.create(request, seller);
+    auctionRepository.save(auction);
+
+    Auction found = auctionRepository.findById(auction.getId()).get();
+
+    assertEquals(seller.getId(), found.getSeller().getId());
+  }
 }

--- a/src/test/java/com/windfall/api/payment/repository/PaymentConfirmRepositoryTest.java
+++ b/src/test/java/com/windfall/api/payment/repository/PaymentConfirmRepositoryTest.java
@@ -1,6 +1,8 @@
 package com.windfall.api.payment.repository;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.windfall.api.auction.dto.request.AuctionCreateRequest;
 import com.windfall.domain.auction.entity.Auction;
@@ -75,5 +77,27 @@ class PaymentConfirmRepositoryTest {
     assertThat(result).isPresent();
     assertThat(result.get().getId()).isEqualTo(trade.getId());
     assertThat(result.get().getAuction().getId()).isEqualTo(auction.getId());
+  }
+
+  @Test
+  void givenUser_whenExistsByUserId_thenReturnTrue() {
+    User user = userRepository.save(
+        new User(ProviderType.GOOGLE, "user_id_1",
+            "user_id_1@gmail.com", "nickname_user_id_1",
+            "profile_image_url_user_1")
+    );
+
+    assertTrue(userRepository.existsById(user.getId()));
+  }
+
+  @Test
+  void givenUser_whenNotExistsByUserId_thenReturnFalse() {
+    User user = userRepository.save(
+        new User(ProviderType.GOOGLE, "user_id_1",
+            "user_id_1@gmail.com", "nickname_user_id_1",
+            "profile_image_url_user_1")
+    );
+
+    assertFalse(userRepository.existsById(999L));
   }
 }

--- a/src/test/java/com/windfall/api/payment/repository/PaymentConfirmRepositoryTest.java
+++ b/src/test/java/com/windfall/api/payment/repository/PaymentConfirmRepositoryTest.java
@@ -1,0 +1,79 @@
+package com.windfall.api.payment.repository;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.windfall.api.auction.dto.request.AuctionCreateRequest;
+import com.windfall.domain.auction.entity.Auction;
+import com.windfall.domain.auction.enums.AuctionCategory;
+import com.windfall.domain.auction.repository.AuctionRepository;
+import com.windfall.domain.trade.entity.Trade;
+import com.windfall.domain.trade.repository.TradeRepository;
+import com.windfall.domain.user.entity.User;
+import com.windfall.domain.user.enums.ProviderType;
+import com.windfall.domain.user.repository.UserRepository;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.ActiveProfiles;
+
+@DataJpaTest
+@ActiveProfiles("test")
+@Import(QuerydslTestConfig.class)
+class PaymentConfirmRepositoryTest {
+
+  @Autowired
+  private TradeRepository tradeRepository;
+
+  @Autowired
+  private AuctionRepository auctionRepository;
+
+  @Autowired
+  private UserRepository userRepository;
+
+  @Test
+  @DisplayName("Auction으로 Trade 조회가 정상 동작한다")
+  void givenAuction_whenFindByAuction_thenReturnTrade() {
+    // given
+    User seller = userRepository.save(
+        new User(ProviderType.GOOGLE, "user_id_1",
+            "user_id_1@gmail.com", "nickname_user_id_1",
+            "profile_image_url_user_1")
+    );
+
+    AuctionCreateRequest request = new AuctionCreateRequest(
+        "test auction",
+        "test description",
+        AuctionCategory.CLOTHING,
+        List.of(),              // tags (optional or empty)
+        List.of(1L, 2L),        // imageIds (필수)
+        1000L,                  // startPrice
+        500L,                   // stopLoss
+        100L,                   // dropAmount
+        LocalDateTime.now().plusHours(1) // startAt (미래 시간 권장)
+    );
+    Auction auction = Auction.create(request, seller);
+    auctionRepository.save(auction);
+
+    Trade trade = tradeRepository.save(
+        Trade.builder()
+            .auction(auction)
+            .sellerId(seller.getId())
+            .buyerId(999L)
+            .finalPrice(1000L)
+            .build()
+    );
+
+    // when
+    Optional<Trade> result = tradeRepository.findByAuction(auction);
+
+    // then
+    assertThat(result).isPresent();
+    assertThat(result.get().getId()).isEqualTo(trade.getId());
+    assertThat(result.get().getAuction().getId()).isEqualTo(auction.getId());
+  }
+}

--- a/src/test/java/com/windfall/api/payment/repository/PaymentConfirmRepositoryTest.java
+++ b/src/test/java/com/windfall/api/payment/repository/PaymentConfirmRepositoryTest.java
@@ -1,13 +1,20 @@
 package com.windfall.api.payment.repository;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.windfall.api.auction.dto.request.AuctionCreateRequest;
 import com.windfall.domain.auction.entity.Auction;
 import com.windfall.domain.auction.enums.AuctionCategory;
 import com.windfall.domain.auction.repository.AuctionRepository;
+import com.windfall.domain.payment.entity.Payment;
+import com.windfall.domain.payment.entity.PaymentSelection;
+import com.windfall.domain.payment.enums.PaymentMethod;
+import com.windfall.domain.payment.enums.PaymentProvider;
+import com.windfall.domain.payment.repository.PaymentRepository;
 import com.windfall.domain.trade.entity.Trade;
 import com.windfall.domain.trade.repository.TradeRepository;
 import com.windfall.domain.user.entity.User;
@@ -36,6 +43,9 @@ class PaymentConfirmRepositoryTest {
 
   @Autowired
   private UserRepository userRepository;
+
+  @Autowired
+  private PaymentRepository paymentRepository;
 
   @Test
   @DisplayName("Auction으로 Trade 조회가 정상 동작한다")
@@ -99,5 +109,16 @@ class PaymentConfirmRepositoryTest {
     );
 
     assertFalse(userRepository.existsById(999L));
+  }
+
+  @Test
+  void givenPayment_whenSaved_thenGenerateIdAndPreservePaymentKey() {
+    Payment payment = Payment.confirm(1L, "key", 1000L,
+        new PaymentSelection(PaymentProvider.TOSS, PaymentMethod.TOSS_PAY));
+
+    Payment saved = paymentRepository.save(payment);
+
+    assertNotNull(saved.getId());
+    assertEquals("key", saved.getPaymentKey());
   }
 }

--- a/src/test/java/com/windfall/api/payment/repository/PaymentConfirmRepositoryTest.java
+++ b/src/test/java/com/windfall/api/payment/repository/PaymentConfirmRepositoryTest.java
@@ -10,6 +10,8 @@ import com.windfall.api.auction.dto.request.AuctionCreateRequest;
 import com.windfall.domain.auction.entity.Auction;
 import com.windfall.domain.auction.enums.AuctionCategory;
 import com.windfall.domain.auction.repository.AuctionRepository;
+import com.windfall.domain.chat.entity.ChatRoom;
+import com.windfall.domain.chat.repository.ChatRoomRepository;
 import com.windfall.domain.payment.entity.Payment;
 import com.windfall.domain.payment.entity.PaymentSelection;
 import com.windfall.domain.payment.enums.PaymentMethod;
@@ -46,6 +48,9 @@ class PaymentConfirmRepositoryTest {
 
   @Autowired
   private PaymentRepository paymentRepository;
+
+  @Autowired
+  private ChatRoomRepository chatRoomRepository;
 
   @Test
   @DisplayName("Auction으로 Trade 조회가 정상 동작한다")
@@ -120,5 +125,44 @@ class PaymentConfirmRepositoryTest {
 
     assertNotNull(saved.getId());
     assertEquals("key", saved.getPaymentKey());
+  }
+
+  @Test
+  void givenTrade_whenGenerateChatRoom_thenSaveChatRoom() {
+
+    User seller = userRepository.save(
+        new User(ProviderType.GOOGLE, "user_id_1",
+            "user_id_1@gmail.com", "nickname_user_id_1",
+            "profile_image_url_user_1")
+    );
+
+    AuctionCreateRequest request = new AuctionCreateRequest(
+        "test auction",
+        "test description",
+        AuctionCategory.CLOTHING,
+        List.of(),              // tags (optional or empty)
+        List.of(1L, 2L),        // imageIds (필수)
+        1000L,                  // startPrice
+        500L,                   // stopLoss
+        100L,                   // dropAmount
+        LocalDateTime.now().plusHours(1) // startAt (미래 시간 권장)
+    );
+    Auction auction = Auction.create(request, seller);
+    auctionRepository.save(auction);
+
+    Trade trade = tradeRepository.save(
+        Trade.builder()
+            .auction(auction)
+            .sellerId(seller.getId())
+            .buyerId(999L)
+            .finalPrice(1000L)
+            .build()
+    );
+
+    ChatRoom chatRoom = ChatRoom.generateChatRoom(trade);
+    chatRoomRepository.save(chatRoom);
+
+    assertNotNull(chatRoom.getId());
+    assertEquals(trade.getId(), chatRoom.getTrade().getId());
   }
 }

--- a/src/test/java/com/windfall/api/payment/repository/QuerydslTestConfig.java
+++ b/src/test/java/com/windfall/api/payment/repository/QuerydslTestConfig.java
@@ -1,0 +1,19 @@
+package com.windfall.api.payment.repository;
+
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+
+@TestConfiguration
+public class QuerydslTestConfig {
+
+  @PersistenceContext
+  private EntityManager entityManager;
+
+  @Bean
+  public JPAQueryFactory jpaQueryFactory() {
+    return new JPAQueryFactory(entityManager);
+  }
+}


### PR DESCRIPTION
## 📌 관련 이슈
- close #8 

## 📝 변경 사항
### AS-IS
- 기존 코드의 동작 방식 설명
- 레포지토리 테스트 존재하지 않음.
- JPA를 통한 조건 조회문 보증 X
- 연관관계 보증 X

### TO-BE
- JPA를 통한 올바른 조건 조회를 하는지 보장함.
- 연관관계가 올바르게 mapping 되었는지 보장함.

## 🔍 테스트
- [x] 테스트 코드 작성
- [ ] API 테스트
- [x] 로컬 테스트

## 📸 스크린샷
<img width="1515" height="946" alt="스크린샷 2026-04-23 154911" src="https://github.com/user-attachments/assets/81c82547-440f-407a-82d2-27fd6f92ce5c" />


## ✅ 체크리스트
- [x] main/develop 브랜치가 아닌 feature 브랜치에서 작성했나요?
- [x] 코딩 컨벤션을 준수했나요?
- [x] 불필요한 코드는 제거했나요?
- [ ] 주석은 충분히 작성했나요?
- [x] 테스트는 완료했나요?

## 🙋‍♂️ 리뷰어에게
