### PR TITLE
[fix] Trade 객체에 auction쪽에 unique 제약 추가 및 통합테스트.

### DIFF
--- a/src/main/java/com/windfall/domain/trade/entity/Trade.java
+++ b/src/main/java/com/windfall/domain/trade/entity/Trade.java
@@ -10,6 +10,8 @@ import jakarta.persistence.Enumerated;
 import jakarta.persistence.FetchType;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -17,6 +19,12 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Entity
+@Table(
+    name = "trade",
+    uniqueConstraints = {
+        @UniqueConstraint(columnNames = "auction_id")
+    }
+)
 @Getter
 @Builder
 @NoArgsConstructor(access = AccessLevel.PROTECTED)

--- a/src/main/java/com/windfall/domain/trade/repository/TradeRepository.java
+++ b/src/main/java/com/windfall/domain/trade/repository/TradeRepository.java
@@ -7,4 +7,5 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface TradeRepository extends JpaRepository<Trade, Long> {
   Optional<Trade> findByAuction(Auction auction);
+  long countByAuction(Auction auction);
 }

--- a/src/test/java/com/windfall/api/payment/integration/trade/TradeCreationUniqueConstraintTest.java
+++ b/src/test/java/com/windfall/api/payment/integration/trade/TradeCreationUniqueConstraintTest.java
@@ -1,0 +1,102 @@
+package com.windfall.api.payment.integration.trade;
+// 두 트랜잭션이 같은 시점에 Trade 조회 후 생성 시,
+// 먼저 조회한 트랜잭션이 있다면, 아직 커밋/롤백 안했어도 다른 트랜잭션은 생성 시도 금지되어야한다.
+
+// 상황:
+//  Thread A, B가
+//   1) 동시에 시작
+//   2) 동일 auctionId로 createTrade 호출
+//   3) 둘 다 find에서 null을 읽음
+//   4) 둘 다 insert 시도
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.windfall.api.auction.dto.request.AuctionCreateRequest;
+import com.windfall.api.auction.dto.request.TagInfo;
+import com.windfall.api.payment.service.PaymentService;
+import com.windfall.domain.auction.entity.Auction;
+import com.windfall.domain.auction.enums.AuctionCategory;
+import com.windfall.domain.auction.repository.AuctionRepository;
+import com.windfall.domain.trade.repository.TradeRepository;
+import com.windfall.domain.user.entity.User;
+import com.windfall.domain.user.enums.ProviderType;
+import com.windfall.domain.user.repository.UserRepository;
+import com.windfall.global.config.PaymentServiceTestConfig;
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+@SpringBootTest(classes = PaymentServiceTestConfig.class)
+public class TradeCreationUniqueConstraintTest {
+
+  @Autowired
+  TradeRepository tradeRepository;
+  @Autowired
+  AuctionRepository auctionRepository;
+  @Autowired
+  UserRepository userRepository;
+  @Autowired
+  PaymentService paymentService;
+
+  private ExecutorService executor = Executors.newFixedThreadPool(2);
+
+  private User user;
+  @BeforeEach
+  void setUp() {
+    user = userRepository.save(
+        new User(ProviderType.KAKAO, "1", "email", "nickname", "imgUrl")
+    );
+  }
+
+  @Test
+  void unique_constraint_allows_only_one_trade_per_auction() throws Exception {
+
+    // given
+    AuctionCreateRequest request = new AuctionCreateRequest("title", "description",
+        AuctionCategory.CLOTHING, new ArrayList<TagInfo>(), new ArrayList<Long>(),
+        1L, 1L, 1L, LocalDateTime.now());
+    userRepository.save(user);
+    Auction auction = auctionRepository.save(
+        Auction.create(request, user));
+
+    // when
+    Future<?> a = executor.submit(() ->
+        paymentService.createTradeIfAbsent(auction, 1L, 1000L)
+    );
+
+    Future<?> b = executor.submit(() ->
+        paymentService.createTradeIfAbsent(auction, 2L, 2000L)
+    );
+
+    Exception exA = null;
+    Exception exB = null;
+
+    try {
+      a.get();
+    } catch (ExecutionException e) {
+      exA = e;
+    }
+
+    try {
+      b.get();
+    } catch (ExecutionException e) {
+      exB = e;
+    }
+
+    // then
+    long count = tradeRepository.countByAuction(auction);
+
+    assertEquals(1, count);
+
+    // 최소 하나는 무조건 실패해야 정상
+    assertTrue(exA != null || exB != null);
+  }
+}


### PR DESCRIPTION
## 📌 관련 이슈
- close #10 

## 📝 변경 사항
### AS-IS
- 기존 코드의 동작 방식 설명
- 시나리오흐름 기반으로, 두 유저가 동시에 들어와 같은 auction에 대해 trade 생성 시도 시, 같은 auction에 대한 trade 객체 2개가 DB에 생성될 수 있는 문제점 발견.
- 이 도메인에선 한 auction엔 trade가 0 or 1개인 1:1 관계 보장되어야 함.

### TO-BE
- 변경된 내용 설명
- DB 계층 문제라, 위 데이터 무결성을 '예방'하는 방법으로 접근.
- Trade 객체에 auction에 대해 Unique 제약 걸어 MySQL에서 같은 auction값을 가진 trade는 1개이도록 강제함.

## 🔍 테스트
- [x] 테스트 코드 작성
- [ ] API 테스트
- [x] 로컬 테스트

## 📸 스크린샷
<img width="995" height="788" alt="스크린샷 2026-05-22 150035" src="https://github.com/user-attachments/assets/33336539-60fb-4dc4-95b8-377b72609ee3" />



## ✅ 체크리스트
- [x] main/develop 브랜치가 아닌 feature 브랜치에서 작성했나요?
- [x] 코딩 컨벤션을 준수했나요?
- [x] 불필요한 코드는 제거했나요?
- [x] 주석은 충분히 작성했나요?
- [x] 테스트는 완료했나요?

## 🙋‍♂️ 리뷰어에게
