### PR TITLE
[fix] DB속 결제 가능한 상태값(FAILED, CANCELD)가진 Trade 객체에 대해 중복 결제 예방 테스트

### DIFF
--- a/src/main/java/com/windfall/api/payment/service/PaymentPostProcessService.java
+++ b/src/main/java/com/windfall/api/payment/service/PaymentPostProcessService.java
@@ -38,51 +38,16 @@ public class PaymentPostProcessService {
     // trade 객체, payment 객체 값과 status 변경, 저장.
     // payment 객체 생성, 값 넣고 저장.
     // 채팅방 객체도 생성, 저장.
-    log.info(
-        "[PaymentConfirm] auction completion start - auctionId={}",
-        auctionId
-    );
-    auctionStateService.completeAuction(auctionId);
-    log.info(
-        "[PaymentConfirm] auction completed - auctionId={}",
-        auctionId
-    );
 
-    log.info(
-        "[PaymentConfirm] trade status change - tradeId={}, from={}, to={}",
-        trade.getId(),
-        trade.getStatus(),
-        TradeStatus.PAYMENT_COMPLETED
-    );
+    auctionStateService.completeAuction(auctionId);
+
     trade.changeStatus(TradeStatus.PAYMENT_COMPLETED);
 
-    log.info(
-        "[PaymentConfirm] payment entity create - tradeId={}, paymentKey={}, amount={}, provider={}, method={}",
-        trade.getId(),
-        paymentKey,
-        amount,
-        PaymentProvider.TOSS,
-        PaymentMethod.MOBILE_PAYMENT
-    );
     Payment payment = Payment.confirm(trade.getId(), paymentKey, amount,
         new PaymentSelection(PaymentProvider.TOSS, PaymentMethod.MOBILE_PAYMENT));
     paymentRepository.save(payment);
-    log.info(
-        "[PaymentConfirm] payment saved - paymentId={}, tradeId={}",
-        payment.getId(),
-        trade.getId()
-    );
 
-    log.info(
-        "[PaymentConfirm] chat room create - tradeId={}",
-        trade.getId()
-    );
     ChatRoom chatRoom = ChatRoom.generateChatRoom(trade);
     chatRoomRepository.save(chatRoom);
-    log.info(
-        "[PaymentConfirm] chat room saved - chatRoomId={}, tradeId={}",
-        chatRoom.getId(),
-        trade.getId()
-    );
   }
 }

--- a/src/main/java/com/windfall/api/payment/service/PaymentService.java
+++ b/src/main/java/com/windfall/api/payment/service/PaymentService.java
@@ -1,5 +1,7 @@
 package com.windfall.api.payment.service;
 
+import static com.windfall.global.exception.ErrorCode.PAYMENT_REQUEST_LATE;
+
 import com.windfall.api.payment.dto.request.PaymentConfirmRequest;
 import com.windfall.api.payment.dto.request.TossPaymentConfirmRequest;
 import com.windfall.api.payment.dto.response.PaymentConfirmResponse;
@@ -14,13 +16,16 @@ import com.windfall.global.exception.ErrorCode;
 import com.windfall.global.exception.ErrorException;
 import java.nio.charset.StandardCharsets;
 import java.util.Base64;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatusCode;
 import org.springframework.http.MediaType;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.reactive.function.client.WebClient;
 import reactor.core.publisher.Mono;
 
@@ -28,6 +33,7 @@ import reactor.core.publisher.Mono;
 @Service
 @RequiredArgsConstructor
 public class PaymentService {
+
   private final WebClient webClient;
   private final AuctionRepository auctionRepository;
   private final TradeRepository tradeRepository;
@@ -39,133 +45,58 @@ public class PaymentService {
   private String widgetSecretKey;
 
   public PaymentConfirmResponse confirmPayment(
-      PaymentConfirmRequest paymentConfirmRequest,
-      Long buyerId) {
-    log.info("Now on PaymentService");
+      PaymentConfirmRequest paymentConfirmRequest, Long buyerId) {
 
     // DTO에서 데이터 추출하며 예외처리.
     String paymentKey = paymentConfirmRequest.paymentKey();
     String orderId = paymentConfirmRequest.orderId();
     Long amount = paymentConfirmRequest.amount();
     Long auctionId = paymentConfirmRequest.auctionId();
-    Auction auction = auctionRepository.findById(auctionId).orElseThrow(() -> new ErrorException(ErrorCode.NOT_FOUND_AUCTION));
+    Auction auction = auctionRepository.findById(auctionId)
+        .orElseThrow(() -> new ErrorException(ErrorCode.NOT_FOUND_AUCTION));
 
-    log.info(
-        "[PaymentConfirm] request received - paymentKey={}, orderId={}, amount={}, auctionId={}",
-        paymentKey,
-        orderId,
-        amount,
-        auctionId
-    );
-    // 테스트용 임시 User seller 값.
-    /*
-    User seller = new User(
-        ProviderType.KAKAO, "providerUserId", "email", "nickname", "imageUrl");
-    userRepository.save(seller);
-    */
-
-    // 테스트용 임시 Auction auction 값.
-    /*
-    Auction auction = Auction.builder()
-        .seller(seller)
-        .title("auctionTitle")
-        .description("auctionDescription")
-        .category(AuctionCategory.CLOTHING)
-        .startPrice(8888L)
-        .currentPrice(7777L)
-        .stopLoss(6666L)
-        .dropAmount(1111L)
-        .startedAt(LocalDateTime.of(2026, 1, 1, 0, 0))
-        .endedAt(LocalDateTime.of(2026, 12, 31, 23, 59))
-        .build();
-    auctionRepository.save(auction);
-    */
-
+    // 올바른 유저인지 확인과 예외처리.
     Long sellerId = auction.getSeller().getId();
-    if(!userRepository.existsById(sellerId)) throw new ErrorException(ErrorCode.NOT_FOUND_SELLER);
-    if(!userRepository.existsById(buyerId)) throw new ErrorException(ErrorCode.NOT_FOUND_BUYER);
-
-    log.info(
-        "[PaymentConfirm] seller/buyer check start - auctionId={}, sellerId={}, buyerId={}",
-        auction.getId(),
-        sellerId,
-        buyerId
-    );
-
-    // 더티체킹 이슈로 상태 분리
-    Trade trade = tradeRepository.findByAuction(auction)
-        .orElse(null);
-    if (trade == null) {
-      trade = Trade.builder()
-          .auction(auction)
-          .sellerId(sellerId)
-          .buyerId(buyerId)
-          .finalPrice(amount)
-          .build();
-      tradeRepository.save(trade); // 신규 엔티티만 save
+    if (!userRepository.existsById(sellerId)) {
+      throw new ErrorException(ErrorCode.NOT_FOUND_SELLER);
+    }
+    if (!userRepository.existsById(buyerId)) {
+      throw new ErrorException(ErrorCode.NOT_FOUND_BUYER);
     }
 
+    // 더티체킹 이슈로 상태 분리
+    Trade trade = acquirePaymentRequestPermission(auction, buyerId, amount);
     final Trade tradeFixed = trade;
-    
+
     // toss api proceed해도 되는지 검증
     validatePaymentRequest(buyerId, trade.getStatus(), trade.getBuyerId());
 
-    TossPaymentConfirmRequest tossRequest = new TossPaymentConfirmRequest(paymentKey, orderId,
-        amount);
-
-    log.info(
-        "[TossConfirm] request start - orderId={}, paymentKey={}, amount={}",
-        tossRequest.orderId(),
-        tossRequest.paymentKey(),
-        tossRequest.amount()
-    );
-
+    // Toss PG사에서 요구하는 암호화
     Base64.Encoder encoder = Base64.getEncoder();
     byte[] encodedBytes = encoder.encode((widgetSecretKey + ":").getBytes(StandardCharsets.UTF_8));
     String authorization = "Basic " + new String(encodedBytes);
 
+    // PG사 결제 승인 요청.
+    TossPaymentConfirmRequest tossRequest = new TossPaymentConfirmRequest(paymentKey, orderId,
+        amount);
     TossPaymentConfirmResponse tossResponse = webClient.post()
-        .uri("https://api.tosspayments.com/v1/payments/confirm")
+        .uri("/v1/payments/confirm")
         .header(HttpHeaders.AUTHORIZATION, authorization)
         .header(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE)
         .bodyValue(tossRequest)
         .retrieve()
         .onStatus(HttpStatusCode::isError, response -> {
-          log.warn(
-              "[TossConfirm] error response - httpStatus={}, orderId={}",
-              response.statusCode(),
-              tossRequest.orderId()
-          );
           tradeFixed.changeStatus(TradeStatus.PAYMENT_FAILED);
           return Mono.error(new ErrorException(ErrorCode.PAYMENT_CONFIRM_FAILED));
         })
         .bodyToMono(TossPaymentConfirmResponse.class)
         .block();
 
-    log.info(
-        "[TossConfirm] success response received - orderId={}, status={}, paymentKey={}, totalAmount={}, method={}",
-        tossResponse.orderId(),
-        tossResponse.status(),
-        tossResponse.paymentKey(),
-        tossResponse.totalAmount(),
-        tossResponse.method()
-    );
-
-    /* // 통신 제외한 로직 테스트용 임시 저장 객체
-    TossPaymentConfirmResponse tossResponse = new TossPaymentConfirmResponse(
-        paymentKey, orderId, 9999L, "카드 결제", "DONE");
-    */
-
-    log.info(
-        "[PaymentConfirm] toss response validation start - orderId={}, totalAmount={}",
-        tossResponse.orderId(),
-        tossResponse.totalAmount()
-    );
-
+    // PG사 응답값 올바른지 확인.
     paymentResponseValidator.validate(tossResponse, tossRequest);
 
-    // db에 저장하는 로직 따로 뺌.
-    paymentPostProcessService.updateDatabaseAfterPayment(auctionId,trade,paymentKey,amount);
+    // db에 결과값 저장.
+    paymentPostProcessService.updateDatabaseAfterPayment(auctionId, trade, paymentKey, amount);
 
     return new PaymentConfirmResponse(
         tossResponse.orderId(), tossResponse.paymentKey(), tossResponse.totalAmount());
@@ -185,10 +116,54 @@ public class PaymentService {
       }
     } else {
       if (!isRetryable) {
-        throw new ErrorException(ErrorCode.PAYMENT_REQUEST_LATE);
+        throw new ErrorException(PAYMENT_REQUEST_LATE);
       }
     }
   }
 
+  @Transactional
+  public Trade acquirePaymentRequestPermission(Auction auction, Long buyerId, Long amount) {
 
+    Trade existingTrade =
+        tradeRepository.findByAuction(auction)
+            .orElse(null);
+
+    // 최초로 trade 생성/UNIQUE로 trade 다수 생성 예방.
+    if (existingTrade == null) {
+
+      Trade newTrade = Trade.builder()
+          .auction(auction)
+          .buyerId(buyerId)
+          .sellerId(auction.getSeller().getId())
+          .finalPrice(amount)
+          .status(TradeStatus.PROCESSING)
+          .build();
+
+      try {
+
+        return tradeRepository.save(newTrade);
+
+      } catch (DataIntegrityViolationException e) {
+
+        throw new ErrorException(PAYMENT_REQUEST_LATE);
+      }
+    }
+
+    // 기존 trade가 결제 가능 상태라면, 결제 요청을 선점 시도(PROCESSING으로 상태 변경)
+    int updated = tradeRepository.reservePaymentProcessing(
+        auction,
+        TradeStatus.PROCESSING,
+        List.of(
+            TradeStatus.PAYMENT_FAILED,
+            TradeStatus.PAYMENT_CANCELED
+        )
+    );
+
+    if (updated == 0) {
+      throw new ErrorException(PAYMENT_REQUEST_LATE);
+    }
+
+    return tradeRepository.findByAuction(auction)
+        .orElseThrow();
+  }
 }

--- a/src/main/java/com/windfall/domain/trade/enums/TradeStatus.java
+++ b/src/main/java/com/windfall/domain/trade/enums/TradeStatus.java
@@ -10,7 +10,8 @@ public enum TradeStatus {
   PAYMENT_CANCELED("결제 취소"),
   PAYMENT_COMPLETED("결제 완료"),
   PURCHASE_CONFIRMED("구매 확정"),
-  PAYMENT_FAILED("결제 실패");
+  PAYMENT_FAILED("결제 실패"),
+  PROCESSING("PG사에 요청 진행중");
 
   private final String description;
 }

--- a/src/main/java/com/windfall/domain/trade/repository/TradeRepository.java
+++ b/src/main/java/com/windfall/domain/trade/repository/TradeRepository.java
@@ -2,10 +2,28 @@ package com.windfall.domain.trade.repository;
 
 import com.windfall.domain.auction.entity.Auction;
 import com.windfall.domain.trade.entity.Trade;
+import com.windfall.domain.trade.enums.TradeStatus;
+import java.util.List;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface TradeRepository extends JpaRepository<Trade, Long> {
   Optional<Trade> findByAuction(Auction auction);
   long countByAuction(Auction auction);
+
+  @Modifying(clearAutomatically = true, flushAutomatically = true)
+  @Query("""
+      UPDATE Trade t
+      SET t.status = :processingStatus
+      WHERE t.auction = :auction
+        AND t.status IN :retryableStatuses
+      """)
+  int reservePaymentProcessing(
+      @Param("auction") Auction auction,
+      @Param("processingStatus") TradeStatus processingStatus,
+      @Param("retryableStatuses") List<TradeStatus> retryableStatuses
+  );
 }

--- a/src/main/java/com/windfall/global/exception/ErrorCode.java
+++ b/src/main/java/com/windfall/global/exception/ErrorCode.java
@@ -71,6 +71,7 @@ public enum ErrorCode {
   NOT_FOUND_BUYER(HttpStatus.NOT_FOUND, "해당 buyerId에 맞는 구매자를 db에서 찾지 못했습니다."),
   NOT_FOUND_SELLER(HttpStatus.NOT_FOUND, "해당 seelerId에 맞는 판매자를 db에서 찾지 못했습니다."),
 
+
   // S3 - 파일 업로드 공통
   INVALID_UPLOAD_FILE(HttpStatus.BAD_REQUEST, "업로드 파일이 유효하지 않습니다."),
   INVALID_DIRECTORY_NAME(HttpStatus.BAD_REQUEST, "디렉토리명이 유효하지 않습니다."),

--- a/src/test/java/com/windfall/api/payment/integration/trade/AcquiringPermissionFromExistingTradeTest.java
+++ b/src/test/java/com/windfall/api/payment/integration/trade/AcquiringPermissionFromExistingTradeTest.java
@@ -1,13 +1,4 @@
 package com.windfall.api.payment.integration.trade;
-// 두 트랜잭션이 같은 시점에 Trade 조회 후 생성 시,
-// 먼저 조회한 트랜잭션이 있다면, 아직 커밋/롤백 안했어도 다른 트랜잭션은 생성 시도 금지되어야한다.
-
-// 상황:
-//  Thread A, B가
-//   1) 동시에 시작
-//   2) 동일 auctionId로 createTrade 호출
-//   3) 둘 다 find에서 null을 읽음
-//   4) 둘 다 insert 시도
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -18,6 +9,8 @@ import com.windfall.api.payment.service.PaymentService;
 import com.windfall.domain.auction.entity.Auction;
 import com.windfall.domain.auction.enums.AuctionCategory;
 import com.windfall.domain.auction.repository.AuctionRepository;
+import com.windfall.domain.trade.entity.Trade;
+import com.windfall.domain.trade.enums.TradeStatus;
 import com.windfall.domain.trade.repository.TradeRepository;
 import com.windfall.domain.user.entity.User;
 import com.windfall.domain.user.enums.ProviderType;
@@ -34,8 +27,9 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 
+
 @SpringBootTest(classes = PaymentServiceTestConfig.class)
-public class TradeCreationUniqueConstraintTest {
+public class AcquiringPermissionFromExistingTradeTest {
 
   @Autowired
   TradeRepository tradeRepository;
@@ -67,9 +61,19 @@ public class TradeCreationUniqueConstraintTest {
     Auction auction = auctionRepository.save(
         Auction.create(request, user));
 
+    Trade trade = Trade.builder()
+        .auction(auction)
+        .buyerId(1L)
+        .sellerId(user.getId())
+        .finalPrice(1000L)
+        .build();
+
+    trade.changeStatus(TradeStatus.PAYMENT_CANCELED);
+    tradeRepository.saveAndFlush(trade);
+
     // when
     Future<?> a = executor.submit(() ->
-        paymentService.acquirePaymentRequestPermission(auction, 1L, 1000L)
+        paymentService.acquirePaymentRequestPermission(auction, 3L, 1000L)
     );
 
     Future<?> b = executor.submit(() ->


### PR DESCRIPTION
## 📌 관련 이슈
- close #12 

## 📝 변경 사항
### AS-IS
- 결제 가능한 상태를 가진 trade에 대해 결제 승인 요청이 빠르게 여러 번 들어오면, 동시성 문제로 PG사 결제 요청이 여러 번 들어갈 수 있음.

### TO-BE
- 결제 가능한 상태를 가진 trade에 대해, 가장 빠른 요청이 DB에게 'PROCESSING'상태로 바꿔달라고 요청.
- 이 상태 바꾸기 요청이 성공했다고 애플리케이션 단에 응답받은 요청만 PG사 결제로 진행 가능.
- 이 상태 바꾸기 요청이 실패했다면 해당 요청은 throw 예외처리. (이미 다른 요청이 결제 진행중입니다)

- 불필요한 로그 삭제

- 통합테스트 성공

## 🔍 테스트
- [x] 테스트 코드 작성
- [ ] API 테스트
- [x] 로컬 테스트

## 📸 스크린샷
기존에 사용하던 함수가 createIfAbsent()였다가, acquirePaymentRequestPermission()로 바뀌었습니다.

이에 따라 기존에 createIfAbsent를 썼던 테스트의 코드도 바꾸고 잘 돌아가는 걸 확인하는 스크린샷입니다.

<img width="1247" height="441" alt="image" src="https://github.com/user-attachments/assets/4eb46fb0-8597-412a-b93a-36d19aadabe6" />

<br><br>
---
결제 가능한 상태를 가진 trade에 대해 통합테스트 통과 스크린샷입니다.
<img width="980" height="377" alt="image" src="https://github.com/user-attachments/assets/0ca2eabd-265e-4091-87de-e9f6b1455351" />




## ✅ 체크리스트
- [x] main/develop 브랜치가 아닌 feature 브랜치에서 작성했나요?
- [x] 코딩 컨벤션을 준수했나요?
- [x] 불필요한 코드는 제거했나요?
- [x] 주석은 충분히 작성했나요?
- [x] 테스트는 완료했나요?

## 🙋‍♂️ 리뷰어에게
// 리뷰어가 집중해서 봐야 하는 부분
// 리뷰어에게 요청하고 싶은 사항