### PR TITLE
[fix] tradeFixed가 아직 필요한지 체크 이후 삭제 또는 유지하는 문제

### DIFF
--- a/src/main/java/com/windfall/api/payment/service/PaymentService.java
+++ b/src/main/java/com/windfall/api/payment/service/PaymentService.java
@@ -64,9 +64,7 @@ public class PaymentService {
       throw new ErrorException(ErrorCode.NOT_FOUND_BUYER);
     }
 
-    // 더티체킹 이슈로 상태 분리
     Trade trade = acquirePaymentRequestPermission(auction, buyerId, amount);
-    final Trade tradeFixed = trade;
 
     // toss api proceed해도 되는지 검증
     validatePaymentRequest(buyerId, trade.getStatus(), trade.getBuyerId());
@@ -86,7 +84,7 @@ public class PaymentService {
         .bodyValue(tossRequest)
         .retrieve()
         .onStatus(HttpStatusCode::isError, response -> {
-          tradeFixed.changeStatus(TradeStatus.PAYMENT_FAILED);
+          trade.changeStatus(TradeStatus.PAYMENT_FAILED);
           return Mono.error(new ErrorException(ErrorCode.PAYMENT_CONFIRM_FAILED));
         })
         .bodyToMono(TossPaymentConfirmResponse.class)


### PR DESCRIPTION


## 📌 관련 이슈
- close #14

## 📝 변경 사항
### AS-IS
초기 개발 시 trade 객체를 초기화 후 다음 단계로 넘어갈 때 더티체킹 에러 로그가 떴다.
당시 응급처치로 final Trade tradeFixed = trade;를 하니 에러 없이 넘어갔다.

### TO-BE
현재 trade 초기화 관련 코드가 많이 바뀌어서, tradeFixed 문제를 재현 시도. -> tradeFixed 없이 초기화된 trade 객체로 다음 단계로 넘어가도 관련 에러가 나지 않는다. 이번 issue에서 tradeFixed 관련해서는 해결.
+ 첨언: validate함수에서 INVALID_TRADE_INIT 예외처리가 된다. validate한 요청 조건 다시 체크 요망.

## 🔍 테스트
- [x] 테스트 코드 작성
- [ ] API 테스트
- [x] 로컬 테스트

## 📸 스크린샷
// UI 변경사항이 있는 경우

## ✅ 체크리스트
- [x] main/develop 브랜치가 아닌 feature 브랜치에서 작성했나요?
- [x] 코딩 컨벤션을 준수했나요?
- [x] 불필요한 코드는 제거했나요?
- [x] 주석은 충분히 작성했나요?
- [x] 테스트는 완료했나요?

## 🙋‍♂️ 리뷰어에게
// 리뷰어가 집중해서 봐야 하는 부분
// 리뷰어에게 요청하고 싶은 사항