### PR TITLE
[fix] trade의 processing 상태 추가 후, 사전 validate 로직 불통과 에러.

### DIFF
--- a/src/main/java/com/windfall/api/payment/service/PaymentService.java
+++ b/src/main/java/com/windfall/api/payment/service/PaymentService.java
@@ -134,7 +134,7 @@ public class PaymentService {
           .buyerId(buyerId)
           .sellerId(auction.getSeller().getId())
           .finalPrice(amount)
-          .status(TradeStatus.PROCESSING)
+          .status(TradeStatus.PENDING)
           .build();
 
       try {

--- a/src/main/java/com/windfall/global/config/WebClientConfig.java
+++ b/src/main/java/com/windfall/global/config/WebClientConfig.java
@@ -1,14 +1,21 @@
 package com.windfall.global.config;
 
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.web.reactive.function.client.WebClient;
 
+
 @Configuration
 public class WebClientConfig {
 
+  @Value("${toss.base-url}")
+  private String baseUrl;
+
   @Bean
   public WebClient webClient() {
-    return WebClient.builder().build();
+    return WebClient.builder()
+        .baseUrl(baseUrl)
+        .build();
   }
 }


### PR DESCRIPTION

## 📌 관련 이슈
- close #16 

## 📝 변경 사항
### AS-IS
- 한 옥션에 대해 최초 trade 생성 및 결제 승인 요청 시, 통과해야 하는 시나리오에서 통과 못하는 문제 발생.

### TO-BE
- 한 auction에 대해 최초 생성하는 trade 객체의 경우, 초기화 시 .PENDING으로 상태 변경.
- 추가로 webClient로 토스 결제 승인 요청 시, toss url/payment/confirm이 아니라 localhost8080/payment/comfirm으로 통신이 향하는 문제를 로그에서 발견 -> baseUrl이란 환경변수 추가해서 해결.


## 🔍 테스트
- [] 테스트 코드 작성
- [x] API 테스트
- [x] 로컬 테스트

## 📸 스크린샷
잘 통과됩니다.
<img width="924" height="841" alt="스크린샷 2026-06-05 151048" src="https://github.com/user-attachments/assets/274f56f2-9ab9-4c26-bdd0-e8b21da82c37" />


## ✅ 체크리스트
- [x] main/develop 브랜치가 아닌 feature 브랜치에서 작성했나요?
- [x] 코딩 컨벤션을 준수했나요?
- [x] 불필요한 코드는 제거했나요?
- [x] 주석은 충분히 작성했나요?
- [x] 테스트는 완료했나요?

## 🙋‍♂️ 리뷰어에게
// 리뷰어가 집중해서 봐야 하는 부분
// 리뷰어에게 요청하고 싶은 사항