### PR TITLE
[feat] 토스결제 외부 api 통신으로 결제 승인 시도 시 confirm() 함수에 retry + exponential …

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -55,6 +55,10 @@ dependencies {
     // 외부 연동
     implementation("org.springframework.boot:spring-boot-starter-webflux")
 
+    // retry용
+    implementation("org.springframework.retry:spring-retry")
+    implementation("org.springframework.boot:spring-boot-starter-aop")
+
     // actuator
     implementation("org.springframework.boot:spring-boot-starter-actuator")
 
@@ -65,6 +69,16 @@ dependencies {
 
     // Elasticsearch
     //implementation("org.springframework.boot:spring-boot-starter-data-elasticsearch")
+
+    // Prometheus
+    // 선행 1: "org.springframework.boot:spring-boot-starter-actuator"
+    // 선행 2: "org.springframework.boot:spring-boot-starter-websocket"
+    implementation("io.micrometer:micrometer-registry-prometheus")
+
+    // Payment Integration Test
+    implementation("com.squareup.okhttp3:mockwebserver:4.12.0")
+    testImplementation("com.squareup.okhttp3:mockwebserver:4.12.0")
+
 }
 
 tasks.withType<Test> {

--- a/src/main/java/com/windfall/api/payment/service/PaymentService.java
+++ b/src/main/java/com/windfall/api/payment/service/PaymentService.java
@@ -6,6 +6,8 @@ import com.windfall.api.payment.dto.request.PaymentConfirmRequest;
 import com.windfall.api.payment.dto.request.TossPaymentConfirmRequest;
 import com.windfall.api.payment.dto.response.PaymentConfirmResponse;
 import com.windfall.api.payment.dto.response.TossPaymentConfirmResponse;
+import com.windfall.api.payment.service.retry.backoff.BackoffStrategy;
+import com.windfall.api.payment.service.retry.backoff.ExponentialFullJitterBackoffStrategy;
 import com.windfall.domain.auction.entity.Auction;
 import com.windfall.domain.auction.repository.AuctionRepository;
 import com.windfall.domain.trade.entity.Trade;
@@ -75,20 +77,14 @@ public class PaymentService {
     String authorization = "Basic " + new String(encodedBytes);
 
     // PG사 결제 승인 요청.
+    BackoffStrategy exponentialFullJitterBackoffStrategy
+        = new ExponentialFullJitterBackoffStrategy(100,2.0,3000);
+
     TossPaymentConfirmRequest tossRequest = new TossPaymentConfirmRequest(paymentKey, orderId,
         amount);
-    TossPaymentConfirmResponse tossResponse = webClient.post()
-        .uri("/v1/payments/confirm")
-        .header(HttpHeaders.AUTHORIZATION, authorization)
-        .header(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE)
-        .bodyValue(tossRequest)
-        .retrieve()
-        .onStatus(HttpStatusCode::isError, response -> {
-          trade.changeStatus(TradeStatus.PAYMENT_FAILED);
-          return Mono.error(new ErrorException(ErrorCode.PAYMENT_CONFIRM_FAILED));
-        })
-        .bodyToMono(TossPaymentConfirmResponse.class)
-        .block();
+
+    TossPaymentConfirmResponse tossResponse
+        = confirm(authorization, tossRequest, trade, exponentialFullJitterBackoffStrategy);
 
     // PG사 응답값 올바른지 확인.
     paymentResponseValidator.validate(tossResponse, tossRequest);
@@ -163,5 +159,56 @@ public class PaymentService {
 
     return tradeRepository.findByAuction(auction)
         .orElseThrow();
+  }
+
+
+  TossPaymentConfirmResponse confirm(
+      String authorization,
+      TossPaymentConfirmRequest tossRequest,
+      Trade trade,
+      BackoffStrategy backoffStrategy){
+
+    int maxAttempts = 5;
+
+    for (int attempt = 1; attempt <= maxAttempts; attempt++) {
+
+      try {
+
+        TossPaymentConfirmResponse tossResponse = webClient.post()
+            .uri("/v1/payments/confirm")
+            .header(HttpHeaders.AUTHORIZATION, authorization)
+            .header(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE)
+            .bodyValue(tossRequest)
+            .retrieve()
+            .onStatus(HttpStatusCode::isError, response ->
+                Mono.error(new ErrorException(ErrorCode.PAYMENT_CONFIRM_FAILED))
+            )
+            .bodyToMono(TossPaymentConfirmResponse.class)
+            .block();
+
+        // 성공
+        return tossResponse;
+
+      } catch (ErrorException e) {
+
+        // 마지막 시도라면 최종 실패
+        if (attempt == maxAttempts) {
+          trade.changeStatus(TradeStatus.PAYMENT_FAILED);
+          throw e;
+        }
+
+        // Full Jitter 대기
+        long delay = backoffStrategy.nextDelay(attempt);
+
+        try {
+          Thread.sleep(delay);
+        } catch (InterruptedException ex) {
+          Thread.currentThread().interrupt();
+          throw new RuntimeException(ex);
+        }
+      }
+    }
+
+    throw new IllegalStateException("Retry loop terminated unexpectedly.");
   }
 }

--- a/src/main/java/com/windfall/api/payment/service/retry/backoff/BackoffStrategy.java
+++ b/src/main/java/com/windfall/api/payment/service/retry/backoff/BackoffStrategy.java
@@ -1,0 +1,11 @@
+package com.windfall.api.payment.service.retry.backoff;
+
+public interface BackoffStrategy {
+  /**
+   * retryCount : 1부터 시작
+   *
+   * @return milliseconds
+   */
+  long nextDelay(int retryCount);
+
+}

--- a/src/main/java/com/windfall/api/payment/service/retry/backoff/ExponentialFullJitterBackoffStrategy.java
+++ b/src/main/java/com/windfall/api/payment/service/retry/backoff/ExponentialFullJitterBackoffStrategy.java
@@ -1,0 +1,54 @@
+// 아래 링크를 참고해서 FULL JITTER를 선택하였습니다.
+// https://aws.amazon.com/ko/blogs/architecture/exponential-backoff-and-jitter/
+
+package com.windfall.api.payment.service.retry.backoff;
+
+import java.util.concurrent.ThreadLocalRandom;
+
+public class ExponentialFullJitterBackoffStrategy implements BackoffStrategy {
+
+  private final long initialInterval;
+  private final double multiplier;
+  private final long maxInterval;
+
+  public ExponentialFullJitterBackoffStrategy(
+      long initialInterval,
+      double multiplier,
+      long maxInterval
+  ) {
+    if (initialInterval <= 0) {
+      throw new IllegalArgumentException("initialInterval must be positive.");
+    }
+
+    if (multiplier < 1.0) {
+      throw new IllegalArgumentException("multiplier must be >= 1.0");
+    }
+
+    if (maxInterval < initialInterval) {
+      throw new IllegalArgumentException(
+          "maxInterval must be >= initialInterval");
+    }
+
+    this.initialInterval = initialInterval;
+    this.multiplier = multiplier;
+    this.maxInterval = maxInterval;
+  }
+
+  @Override
+  public long nextDelay(int retryCount) {
+
+    if (retryCount <= 0) {
+      throw new IllegalArgumentException(
+          "retryCount must start from 1.");
+    }
+
+    double exponential =
+        initialInterval * Math.pow(multiplier, retryCount - 1);
+
+    long capped =
+        Math.min((long) exponential, maxInterval);
+
+    return ThreadLocalRandom.current()
+        .nextLong(capped + 1);
+  }
+}

--- a/src/main/java/com/windfall/global/config/WebClientConfig.java
+++ b/src/main/java/com/windfall/global/config/WebClientConfig.java
@@ -9,7 +9,7 @@ import org.springframework.web.reactive.function.client.WebClient;
 @Configuration
 public class WebClientConfig {
 
-  @Value("${toss.base-url}")
+  @Value("${spring.toss.base-url}")
   private String baseUrl;
 
   @Bean


### PR DESCRIPTION
## 📌 관련 이슈
- close #18 

## 📝 변경 사항
### AS-IS
- 일시적 db, 네트워크 에러에 대해서 대응 수단 없음.

### TO-BE
- 재시도 적용.
- exponential back off 적용
- aws 문서를 참고하여 full jitter exponential back off 적용.
- spring retry는 제한된 시간 내에 공부 시간, 모듈 갯수 증가 문제로 이번 issue에선 배제.
- 단일 모듈 confirm에 대부분 구현.

## 🔍 테스트
- [ ] 테스트 코드 작성
- [ ] API 테스트
- [x] 로컬 테스트

## 📸 스크린샷
- 적용 후에도 결제 승인 api 정상작동합니다.
<img width="1712" height="767" alt="스크린샷 2026-06-26 141641" src="https://github.com/user-attachments/assets/8b51d51f-8c57-47f8-b666-3115316a5d89" />

## ✅ 체크리스트
- [x] main/develop 브랜치가 아닌 feature 브랜치에서 작성했나요?
- [x] 코딩 컨벤션을 준수했나요?
- [x] 불필요한 코드는 제거했나요?
- [x] 주석은 충분히 작성했나요?
- [x] 테스트는 완료했나요?

## 🙋‍♂️ 리뷰어에게
- 나중에 다른 PG사나 다른 외부연동 api 추가 시, 이때 리팩토링 겸 구조변화 필요성 느낌.