### PR TITLE
[fix] PG사 요청 전 검증이란 역할로 묶어 PaymentPreProcessService.java로 분리.

### DIFF
--- a/src/main/java/com/windfall/api/payment/service/PaymentService.java
+++ b/src/main/java/com/windfall/api/payment/service/PaymentService.java
@@ -6,6 +6,7 @@ import com.windfall.api.payment.dto.request.PaymentConfirmRequest;
 import com.windfall.api.payment.dto.request.TossPaymentConfirmRequest;
 import com.windfall.api.payment.dto.response.PaymentConfirmResponse;
 import com.windfall.api.payment.dto.response.TossPaymentConfirmResponse;
+import com.windfall.api.payment.service.retry.PaymentPreProcessService;
 import com.windfall.api.payment.service.retry.backoff.BackoffStrategy;
 import com.windfall.api.payment.service.retry.backoff.ExponentialFullJitterBackoffStrategy;
 import com.windfall.domain.auction.entity.Auction;
@@ -40,6 +41,7 @@ public class PaymentService {
   private final AuctionRepository auctionRepository;
   private final TradeRepository tradeRepository;
   private final UserRepository userRepository;
+  private final PaymentPreProcessService paymentPreProcessService;
   private final PaymentPostProcessService paymentPostProcessService;
   private final PaymentResponseValidator paymentResponseValidator;
 
@@ -66,10 +68,10 @@ public class PaymentService {
       throw new ErrorException(ErrorCode.NOT_FOUND_BUYER);
     }
 
-    Trade trade = acquirePaymentRequestPermission(auction, buyerId, amount);
+    Trade trade = paymentPreProcessService.acquirePaymentRequestPermission(auction, buyerId, amount);
 
     // toss api proceed해도 되는지 검증
-    validatePaymentRequest(buyerId, trade.getStatus(), trade.getBuyerId());
+    paymentPreProcessService.validatePaymentRequest(buyerId, trade.getStatus(), trade.getBuyerId());
 
     // Toss PG사에서 요구하는 암호화
     Base64.Encoder encoder = Base64.getEncoder();

--- a/src/main/java/com/windfall/api/payment/service/retry/PaymentPreProcessService.java
+++ b/src/main/java/com/windfall/api/payment/service/retry/PaymentPreProcessService.java
@@ -1,0 +1,88 @@
+package com.windfall.api.payment.service.retry;
+
+import static com.windfall.global.exception.ErrorCode.PAYMENT_REQUEST_LATE;
+
+import com.windfall.domain.auction.entity.Auction;
+import com.windfall.domain.trade.entity.Trade;
+import com.windfall.domain.trade.enums.TradeStatus;
+import com.windfall.domain.trade.repository.TradeRepository;
+import com.windfall.global.exception.ErrorCode;
+import com.windfall.global.exception.ErrorException;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class PaymentPreProcessService {
+
+  private final TradeRepository tradeRepository;
+
+  // toss api proceed해도 되는지 검증용 함수
+  public void validatePaymentRequest(Long tradeBuyerId, TradeStatus status, Long requestBuyerId) {
+
+    boolean isSameBuyer = tradeBuyerId.equals(requestBuyerId);
+    boolean isRetryable =
+        status == TradeStatus.PAYMENT_CANCELED
+            || status == TradeStatus.PAYMENT_FAILED;
+
+    if (isSameBuyer) {
+      if (status != TradeStatus.PENDING) {
+        throw new ErrorException(ErrorCode.INVALID_TRADE_INIT);
+      }
+    } else {
+      if (!isRetryable) {
+        throw new ErrorException(PAYMENT_REQUEST_LATE);
+      }
+    }
+  }
+
+  @Transactional
+  public Trade acquirePaymentRequestPermission(Auction auction, Long buyerId, Long amount) {
+
+    Trade existingTrade =
+        tradeRepository.findByAuction(auction)
+            .orElse(null);
+
+    // 최초로 trade 생성/UNIQUE로 trade 다수 생성 예방.
+    if (existingTrade == null) {
+
+      Trade newTrade = Trade.builder()
+          .auction(auction)
+          .buyerId(buyerId)
+          .sellerId(auction.getSeller().getId())
+          .finalPrice(amount)
+          .status(TradeStatus.PENDING)
+          .build();
+
+      try {
+
+        return tradeRepository.save(newTrade);
+
+      } catch (DataIntegrityViolationException e) {
+
+        throw new ErrorException(PAYMENT_REQUEST_LATE);
+      }
+    }
+
+    // 기존 trade가 결제 가능 상태라면, 결제 요청을 선점 시도(PROCESSING으로 상태 변경)
+    int updated = tradeRepository.reservePaymentProcessing(
+        auction,
+        TradeStatus.PROCESSING,
+        List.of(
+            TradeStatus.PAYMENT_FAILED,
+            TradeStatus.PAYMENT_CANCELED
+        )
+    );
+
+    if (updated == 0) {
+      throw new ErrorException(PAYMENT_REQUEST_LATE);
+    }
+
+    return tradeRepository.findByAuction(auction)
+        .orElseThrow();
+  }
+
+}

--- a/src/test/java/com/windfall/global/config/PaymentServiceTestConfig.java
+++ b/src/test/java/com/windfall/global/config/PaymentServiceTestConfig.java
@@ -3,6 +3,7 @@ package com.windfall.global.config;
 import com.windfall.api.payment.service.PaymentPostProcessService;
 import com.windfall.api.payment.service.PaymentResponseValidator;
 import com.windfall.api.payment.service.PaymentService;
+import com.windfall.api.payment.service.retry.PaymentPreProcessService;
 import com.windfall.domain.auction.repository.AuctionRepository;
 import com.windfall.domain.trade.repository.TradeRepository;
 import com.windfall.domain.user.repository.UserRepository;
@@ -22,6 +23,7 @@ public class PaymentServiceTestConfig {
       AuctionRepository auctionRepository,
       TradeRepository tradeRepository,
       UserRepository userRepository,
+      PaymentPreProcessService paymentPreProcessService,
       PaymentPostProcessService paymentPostProcessService,
       PaymentResponseValidator paymentResponseValidator
   ) {
@@ -30,6 +32,7 @@ public class PaymentServiceTestConfig {
         auctionRepository,
         tradeRepository,
         userRepository,
+        paymentPreProcessService,
         paymentPostProcessService,
         paymentResponseValidator
     );


### PR DESCRIPTION
## 📌 관련 이슈
- close #22 

## 📝 변경 사항
### AS-IS
- 동일 클래스 내부의 @Transactional 함수를 사용해서 springAOP 우회하는 문제.

### TO-BE
- PG사 외부연동 요청 이전 전처리 단계라는 의미로 PaymentPreProcessService.java로 클래스 분리.
- PaymentService가 PaymentPreProcessService를 Spring Bean으로 주입받아 호출하도록 변경
- Bean 간 호출을 통해 Spring AOP Proxy를 거치도록 수정하여 @Transactional이 정상 적용되도록 개선했습니다.

## 🔍 테스트
- [ ] 테스트 코드 작성
- [ ] API 테스트
- [ ] 로컬 테스트

## 📸 스크린샷
// UI 변경사항이 있는 경우

## ✅ 체크리스트
- [x] main/develop 브랜치가 아닌 feature 브랜치에서 작성했나요?
- [x] 코딩 컨벤션을 준수했나요?
- [x] 불필요한 코드는 제거했나요?
- [x] 주석은 충분히 작성했나요?
- [ ] 테스트는 완료했나요?

## 🙋‍♂️ 리뷰어에게
// 리뷰어가 집중해서 봐야 하는 부분
// 리뷰어에게 요청하고 싶은 사항