### PR TITLE
[fix] 원자적 sql문이 추가되었음에 따라 application 레벨의 validation로직은 불필요해져서 삭제.

### DIFF
--- a/src/main/java/com/windfall/api/payment/service/PaymentService.java
+++ b/src/main/java/com/windfall/api/payment/service/PaymentService.java
@@ -70,9 +70,6 @@ public class PaymentService {
 
     Trade trade = paymentPreProcessService.acquirePaymentRequestPermission(auction, buyerId, amount);
 
-    // toss api proceed해도 되는지 검증
-    paymentPreProcessService.validatePaymentRequest(buyerId, trade.getStatus(), trade.getBuyerId());
-
     // Toss PG사에서 요구하는 암호화
     Base64.Encoder encoder = Base64.getEncoder();
     byte[] encodedBytes = encoder.encode((widgetSecretKey + ":").getBytes(StandardCharsets.UTF_8));

--- a/src/main/java/com/windfall/api/payment/service/retry/PaymentPreProcessService.java
+++ b/src/main/java/com/windfall/api/payment/service/retry/PaymentPreProcessService.java
@@ -6,7 +6,6 @@ import com.windfall.domain.auction.entity.Auction;
 import com.windfall.domain.trade.entity.Trade;
 import com.windfall.domain.trade.enums.TradeStatus;
 import com.windfall.domain.trade.repository.TradeRepository;
-import com.windfall.global.exception.ErrorCode;
 import com.windfall.global.exception.ErrorException;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
@@ -19,25 +18,6 @@ import org.springframework.transaction.annotation.Transactional;
 public class PaymentPreProcessService {
 
   private final TradeRepository tradeRepository;
-
-  // toss api proceed해도 되는지 검증용 함수
-  public void validatePaymentRequest(Long tradeBuyerId, TradeStatus status, Long requestBuyerId) {
-
-    boolean isSameBuyer = tradeBuyerId.equals(requestBuyerId);
-    boolean isRetryable =
-        status == TradeStatus.PAYMENT_CANCELED
-            || status == TradeStatus.PAYMENT_FAILED;
-
-    if (isSameBuyer) {
-      if (status != TradeStatus.PENDING) {
-        throw new ErrorException(ErrorCode.INVALID_TRADE_INIT);
-      }
-    } else {
-      if (!isRetryable) {
-        throw new ErrorException(PAYMENT_REQUEST_LATE);
-      }
-    }
-  }
 
   @Transactional
   public Trade acquirePaymentRequestPermission(Auction auction, Long buyerId, Long amount) {


### PR DESCRIPTION
## 📌 관련 이슈
- close #24 

## 📝 변경 사항
### AS-IS
- 기존에 SQL문 추가로 굳이 application 레벨에서 trade 객체 가져와서 상태 조건 체크할 이유가 사라졌었음.
- 신규 SQL문 진행 이후 기존 validation코드 순으로 진행 시 성공한 객체가 validation에서 막히는 자승자박 코드가 되었었음. 

### TO-BE
- validation 자체가 불필요해져서 해당 코드 삭제.

## 🔍 테스트
- [ ] 테스트 코드 작성
- [ ] API 테스트
- [ ] 로컬 테스트

## 📸 스크린샷
// UI 변경사항이 있는 경우

## ✅ 체크리스트
- [x] main/develop 브랜치가 아닌 feature 브랜치에서 작성했나요?
- [x] 코딩 컨벤션을 준수했나요?
- [x] 불필요한 코드는 제거했나요?
- [x] 주석은 충분히 작성했나요?
- [ ] 테스트는 완료했나요?

## 🙋‍♂️ 리뷰어에게
// 리뷰어가 집중해서 봐야 하는 부분
// 리뷰어에게 요청하고 싶은 사항