### PR TITLE
[fix] PG사 통신 후 실패 시 해당 trade 상태를 FAILED로 즉각 DB에 변경.

### DIFF
--- a/src/main/java/com/windfall/api/payment/service/PaymentService.java
+++ b/src/main/java/com/windfall/api/payment/service/PaymentService.java
@@ -19,16 +19,13 @@ import com.windfall.global.exception.ErrorCode;
 import com.windfall.global.exception.ErrorException;
 import java.nio.charset.StandardCharsets;
 import java.util.Base64;
-import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatusCode;
 import org.springframework.http.MediaType;
 import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.reactive.function.client.WebClient;
 import reactor.core.publisher.Mono;
 
@@ -114,53 +111,6 @@ public class PaymentService {
     }
   }
 
-  @Transactional
-  public Trade acquirePaymentRequestPermission(Auction auction, Long buyerId, Long amount) {
-
-    Trade existingTrade =
-        tradeRepository.findByAuction(auction)
-            .orElse(null);
-
-    // 최초로 trade 생성/UNIQUE로 trade 다수 생성 예방.
-    if (existingTrade == null) {
-
-      Trade newTrade = Trade.builder()
-          .auction(auction)
-          .buyerId(buyerId)
-          .sellerId(auction.getSeller().getId())
-          .finalPrice(amount)
-          .status(TradeStatus.PENDING)
-          .build();
-
-      try {
-
-        return tradeRepository.save(newTrade);
-
-      } catch (DataIntegrityViolationException e) {
-
-        throw new ErrorException(PAYMENT_REQUEST_LATE);
-      }
-    }
-
-    // 기존 trade가 결제 가능 상태라면, 결제 요청을 선점 시도(PROCESSING으로 상태 변경)
-    int updated = tradeRepository.reservePaymentProcessing(
-        auction,
-        TradeStatus.PROCESSING,
-        List.of(
-            TradeStatus.PAYMENT_FAILED,
-            TradeStatus.PAYMENT_CANCELED
-        )
-    );
-
-    if (updated == 0) {
-      throw new ErrorException(PAYMENT_REQUEST_LATE);
-    }
-
-    return tradeRepository.findByAuction(auction)
-        .orElseThrow();
-  }
-
-
   TossPaymentConfirmResponse confirm(
       String authorization,
       TossPaymentConfirmRequest tossRequest,
@@ -192,7 +142,7 @@ public class PaymentService {
 
         // 마지막 시도라면 최종 실패
         if (attempt == maxAttempts) {
-          trade.changeStatus(TradeStatus.PAYMENT_FAILED);
+          tradeRepository.updateStatus(trade.getId(), TradeStatus.PAYMENT_FAILED);
           throw e;
         }
 

--- a/src/main/java/com/windfall/domain/trade/repository/TradeRepository.java
+++ b/src/main/java/com/windfall/domain/trade/repository/TradeRepository.java
@@ -26,4 +26,8 @@ public interface TradeRepository extends JpaRepository<Trade, Long> {
       @Param("processingStatus") TradeStatus processingStatus,
       @Param("retryableStatuses") List<TradeStatus> retryableStatuses
   );
+
+  @Modifying(clearAutomatically = true, flushAutomatically = true)
+  @Query("UPDATE Trade t SET t.status = :status WHERE t.id = :id")
+  int updateStatus(@Param("id") Long id, @Param("status") TradeStatus status);
 }

--- a/src/test/java/com/windfall/api/payment/integration/trade/AcquiringPermissionFromExistingTradeTest.java
+++ b/src/test/java/com/windfall/api/payment/integration/trade/AcquiringPermissionFromExistingTradeTest.java
@@ -6,6 +6,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import com.windfall.api.auction.dto.request.AuctionCreateRequest;
 import com.windfall.api.auction.dto.request.TagInfo;
 import com.windfall.api.payment.service.PaymentService;
+import com.windfall.api.payment.service.retry.PaymentPreProcessService;
 import com.windfall.domain.auction.entity.Auction;
 import com.windfall.domain.auction.enums.AuctionCategory;
 import com.windfall.domain.auction.repository.AuctionRepository;
@@ -39,6 +40,8 @@ public class AcquiringPermissionFromExistingTradeTest {
   UserRepository userRepository;
   @Autowired
   PaymentService paymentService;
+  @Autowired
+  PaymentPreProcessService paymentPreProcessService;
 
   private ExecutorService executor = Executors.newFixedThreadPool(2);
 
@@ -73,11 +76,11 @@ public class AcquiringPermissionFromExistingTradeTest {
 
     // when
     Future<?> a = executor.submit(() ->
-        paymentService.acquirePaymentRequestPermission(auction, 3L, 1000L)
+        paymentPreProcessService.acquirePaymentRequestPermission(auction, 3L, 1000L)
     );
 
     Future<?> b = executor.submit(() ->
-        paymentService.acquirePaymentRequestPermission(auction, 2L, 2000L)
+        paymentPreProcessService.acquirePaymentRequestPermission(auction, 2L, 2000L)
     );
 
     Exception exA = null;

--- a/src/test/java/com/windfall/api/payment/integration/trade/TradeCreationUniqueConstraintTest.java
+++ b/src/test/java/com/windfall/api/payment/integration/trade/TradeCreationUniqueConstraintTest.java
@@ -15,6 +15,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import com.windfall.api.auction.dto.request.AuctionCreateRequest;
 import com.windfall.api.auction.dto.request.TagInfo;
 import com.windfall.api.payment.service.PaymentService;
+import com.windfall.api.payment.service.retry.PaymentPreProcessService;
 import com.windfall.domain.auction.entity.Auction;
 import com.windfall.domain.auction.enums.AuctionCategory;
 import com.windfall.domain.auction.repository.AuctionRepository;
@@ -45,6 +46,8 @@ public class TradeCreationUniqueConstraintTest {
   UserRepository userRepository;
   @Autowired
   PaymentService paymentService;
+  @Autowired
+  PaymentPreProcessService paymentPreProcessService;
 
   private ExecutorService executor = Executors.newFixedThreadPool(2);
 
@@ -69,11 +72,11 @@ public class TradeCreationUniqueConstraintTest {
 
     // when
     Future<?> a = executor.submit(() ->
-        paymentService.acquirePaymentRequestPermission(auction, 1L, 1000L)
+        paymentPreProcessService.acquirePaymentRequestPermission(auction, 1L, 1000L)
     );
 
     Future<?> b = executor.submit(() ->
-        paymentService.acquirePaymentRequestPermission(auction, 2L, 2000L)
+        paymentPreProcessService.acquirePaymentRequestPermission(auction, 2L, 2000L)
     );
 
     Exception exA = null;


### PR DESCRIPTION
## 📌 관련 이슈
- close #26

## 📝 변경 사항
### AS-IS
- PG사 통신으로 요청 시 실패 반환인 경우 해당 trade 객체 상태도 db에 바로 FAILED 처리시켜야 했음.
- 그러나 JPA로 구현해서 즉각적으로 db에 반영 안되는 오류.

### TO-BE
- JPA를 SQL문으로 변경. 즉각 db 반영.

## 🔍 테스트
- [ ] 테스트 코드 작성
- [ ] API 테스트
- [ ] 로컬 테스트

## 📸 스크린샷
// UI 변경사항이 있는 경우

## ✅ 체크리스트
- [x] main/develop 브랜치가 아닌 feature 브랜치에서 작성했나요?
- [x] 코딩 컨벤션을 준수했나요?
- [x] 불필요한 코드는 제거했나요?
- [x] 주석은 충분히 작성했나요?
- [ ] 테스트는 완료했나요?

## 🙋‍♂️ 리뷰어에게
// 리뷰어가 집중해서 봐야 하는 부분
// 리뷰어에게 요청하고 싶은 사항