### PR TITLE
Feat/idempotency key

### DIFF
--- a/src/main/java/com/windfall/api/payment/service/PaymentService.java
+++ b/src/main/java/com/windfall/api/payment/service/PaymentService.java
@@ -66,6 +66,13 @@ public class PaymentService {
     }
 
     Trade trade = paymentPreProcessService.acquirePaymentRequestPermission(auction, buyerId, amount);
+    // 테스트용
+    log.info(
+        "Payment request claim success. auctionId={}, buyerId={}, tradeId={}",
+        auctionId,
+        buyerId,
+        trade.getId()
+    );
 
     // Toss PG사에서 요구하는 암호화
     Base64.Encoder encoder = Base64.getEncoder();
@@ -79,8 +86,27 @@ public class PaymentService {
     TossPaymentConfirmRequest tossRequest = new TossPaymentConfirmRequest(paymentKey, orderId,
         amount);
 
+    log.info("[TEST] First confirm request");
     TossPaymentConfirmResponse tossResponse
-        = confirm(authorization, tossRequest, trade, exponentialFullJitterBackoffStrategy);
+        = confirm(authorization, tossRequest, trade,
+        exponentialFullJitterBackoffStrategy, paymentKey);
+    log.info(
+        "[TEST] First response paymentKey={}, orderId={}, totalAmount={}",
+        tossResponse.paymentKey(),
+        tossResponse.orderId(),
+        tossResponse.totalAmount()
+    );
+
+    log.info("[TEST] Second confirm request");
+    TossPaymentConfirmResponse secondResponse
+        = confirm(authorization, tossRequest, trade,
+        exponentialFullJitterBackoffStrategy, paymentKey);
+    log.info(
+        "[TEST] Second response paymentKey={}, orderId={}, totalAmount={}",
+        secondResponse.paymentKey(),
+        secondResponse.orderId(),
+        secondResponse.totalAmount()
+    );
 
     // PG사 응답값 올바른지 확인.
     paymentResponseValidator.validate(tossResponse, tossRequest);
@@ -115,7 +141,8 @@ public class PaymentService {
       String authorization,
       TossPaymentConfirmRequest tossRequest,
       Trade trade,
-      BackoffStrategy backoffStrategy){
+      BackoffStrategy backoffStrategy,
+      String idempotencyKey){
 
     int maxAttempts = 5;
 
@@ -127,6 +154,7 @@ public class PaymentService {
             .uri("/v1/payments/confirm")
             .header(HttpHeaders.AUTHORIZATION, authorization)
             .header(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE)
+            .header("Idempotency-Key", idempotencyKey)
             .bodyValue(tossRequest)
             .retrieve()
             .onStatus(HttpStatusCode::isError, response ->

--- a/src/main/java/com/windfall/api/payment/service/PaymentService.java
+++ b/src/main/java/com/windfall/api/payment/service/PaymentService.java
@@ -86,27 +86,9 @@ public class PaymentService {
     TossPaymentConfirmRequest tossRequest = new TossPaymentConfirmRequest(paymentKey, orderId,
         amount);
 
-    log.info("[TEST] First confirm request");
     TossPaymentConfirmResponse tossResponse
         = confirm(authorization, tossRequest, trade,
         exponentialFullJitterBackoffStrategy, paymentKey);
-    log.info(
-        "[TEST] First response paymentKey={}, orderId={}, totalAmount={}",
-        tossResponse.paymentKey(),
-        tossResponse.orderId(),
-        tossResponse.totalAmount()
-    );
-
-    log.info("[TEST] Second confirm request");
-    TossPaymentConfirmResponse secondResponse
-        = confirm(authorization, tossRequest, trade,
-        exponentialFullJitterBackoffStrategy, paymentKey);
-    log.info(
-        "[TEST] Second response paymentKey={}, orderId={}, totalAmount={}",
-        secondResponse.paymentKey(),
-        secondResponse.orderId(),
-        secondResponse.totalAmount()
-    );
 
     // PG사 응답값 올바른지 확인.
     paymentResponseValidator.validate(tossResponse, tossRequest);


### PR DESCRIPTION
## 📌 관련 이슈
- close #29 

## 📝 변경 사항
### AS-IS
- retry 로직이 구현된 상태에서 실제 재시도 시 각종 장애로 중복 결제될 수 있음.

### TO-BE
- 고유한 값인 paymentKey를 idempotencyKey로 하여서 중복 결제 방지.

## 🔍 테스트
- [x] 테스트 코드 작성
- [x] API 테스트
- [x] 로컬 테스트

## 📸 스크린샷
- 테스트 방법으로 1번 결제 요청에 대해 toss api에 결제승인 요청 2번 보내기를 하였습니다.
- 스크린샷 기준으로, 아래쪽 2개(07-25-15:52인 2개)가 대조군으로 idempotency key 없이 진행한 것입니다.
- 반면 위쪽 1개(07-25-16:03)가 idempotency key를 추가하여 진행한 것입니다.
<img width="1012" height="527" alt="토스 api로그의 결과 - idempotency 처리한 요청은 2번 요청 보내어도 1번만 적용되었다! - 복사본" src="https://github.com/user-attachments/assets/1e1887df-fa26-441d-b879-f2783cc723ee" />
- application 응답으로는 idempotency key를 적용해도 요청 2번에 대해 모두 200이 옵니다.
- 그 이유는 멱등성 보장에 따라 두 번째 요청을 처리하지 않고, 첫 번째 요청 처리 결과를 그대로 반환하기 때문입니다.



## ✅ 체크리스트
- [x] main/develop 브랜치가 아닌 feature 브랜치에서 작성했나요?
- [x] 코딩 컨벤션을 준수했나요?
- [x] 불필요한 코드는 제거했나요?
- [x] 주석은 충분히 작성했나요?
- [x] 테스트는 완료했나요?

## 🙋‍♂️ 리뷰어에게
// 리뷰어가 집중해서 봐야 하는 부분
// 리뷰어에게 요청하고 싶은 사항