### PR TITLE
[Fix] trade의 상태 PENDING을 PROCESSING에 통합. 이제 PROCESSING은 결제 진행중이란 뜻으로 …

### DIFF
--- a/src/main/java/com/windfall/api/payment/service/PaymentService.java
+++ b/src/main/java/com/windfall/api/payment/service/PaymentService.java
@@ -109,7 +109,7 @@ public class PaymentService {
             || status == TradeStatus.PAYMENT_FAILED;
 
     if (isSameBuyer) {
-      if (status != TradeStatus.PENDING) {
+      if (status != TradeStatus.PROCESSING) {
         throw new ErrorException(ErrorCode.INVALID_TRADE_INIT);
       }
     } else {

--- a/src/main/java/com/windfall/api/payment/service/retry/PaymentPreProcessService.java
+++ b/src/main/java/com/windfall/api/payment/service/retry/PaymentPreProcessService.java
@@ -9,10 +9,12 @@ import com.windfall.domain.trade.repository.TradeRepository;
 import com.windfall.global.exception.ErrorException;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 public class PaymentPreProcessService {
@@ -34,7 +36,7 @@ public class PaymentPreProcessService {
           .buyerId(buyerId)
           .sellerId(auction.getSeller().getId())
           .finalPrice(amount)
-          .status(TradeStatus.PENDING)
+          .status(TradeStatus.PROCESSING)
           .build();
 
       try {
@@ -42,7 +44,7 @@ public class PaymentPreProcessService {
         return tradeRepository.save(newTrade);
 
       } catch (DataIntegrityViolationException e) {
-
+        log.warn("[RACE] UNIQUE constraint blocked duplicate trade. auctionId={}", auction.getId());
         throw new ErrorException(PAYMENT_REQUEST_LATE);
       }
     }
@@ -58,6 +60,7 @@ public class PaymentPreProcessService {
     );
 
     if (updated == 0) {
+      log.warn("[RACE] Conditional UPDATE blocked re-entry. auctionId={}", auction.getId());
       throw new ErrorException(PAYMENT_REQUEST_LATE);
     }
 

--- a/src/main/java/com/windfall/domain/trade/entity/Trade.java
+++ b/src/main/java/com/windfall/domain/trade/entity/Trade.java
@@ -44,7 +44,7 @@ public class Trade extends BaseEntity {
   @Builder.Default
   @Enumerated(EnumType.STRING)
   @Column(nullable = false)
-  private TradeStatus status = TradeStatus.PENDING;
+  private TradeStatus status = TradeStatus.PROCESSING;
 
   @Column(name = "final_price", nullable = false)
   private Long finalPrice;

--- a/src/main/java/com/windfall/domain/trade/enums/TradeStatus.java
+++ b/src/main/java/com/windfall/domain/trade/enums/TradeStatus.java
@@ -6,12 +6,11 @@ import lombok.Getter;
 @Getter
 @AllArgsConstructor
 public enum TradeStatus {
-  PENDING("결제 대기"),
   PAYMENT_CANCELED("결제 취소"),
   PAYMENT_COMPLETED("결제 완료"),
   PURCHASE_CONFIRMED("구매 확정"),
   PAYMENT_FAILED("결제 실패"),
-  PROCESSING("PG사에 요청 진행중");
+  PROCESSING("결제 진행 중");
 
   private final String description;
 }

--- a/src/test/java/com/windfall/api/payment/service/PaymentServiceValidatePaymentRequestTest.java
+++ b/src/test/java/com/windfall/api/payment/service/PaymentServiceValidatePaymentRequestTest.java
@@ -58,11 +58,11 @@ public class PaymentServiceValidatePaymentRequestTest {
     );
   }
 
-  // 4. 타인 + PENDING → PAYMENT_REQUEST_LATE
+  // 4. 타인 + PROCESSING → PAYMENT_REQUEST_LATE
   @Test
   void throws_payment_request_late_when_other_buyer_and_status_is_not_retryable_pending() {
     ErrorException ex = assertThrows(ErrorException.class, () ->
-        service.validatePaymentRequest(1L, TradeStatus.PENDING, 2L)
+        service.validatePaymentRequest(1L, TradeStatus.PROCESSING, 2L)
     );
 
     assertEquals(ErrorCode.PAYMENT_REQUEST_LATE, ex.getErrorCode());


### PR DESCRIPTION
…통일. 실제 결제 단계 추적은 Payment.status가 맡기로 결정하며 trade와 payment 역할 분리.

## 📌 관련 이슈
- close #31 

## 📝 변경 사항
### AS-IS
- trade에 외부에 보여줄 결제 상태 표시, 결제 프로세스 단계 추적용 상태 표시라는 2가지 책임이 동시부여되어 있었습니다.
- 예를 들어 trade에 'trade 객체 생성 후 결제 진행 전', '결제 요청 후 기다리는 중', '결제 응답 받고 db 저장 전', 'db 저장 중', 'db 저장 완료' 등등을 적으면 외부(프론트) 입장에선 내부 로직을 모르기에 직관성이 떨어집니다.

### TO-BE
- 거래 상태 자체를 정의하는 것은 trade.status로 진행 중, 성공, 실패, 취소로만 둡니다.
- 거래 내부 로직이 현재 어느 단계 진행 중인지를 추적해서 디버깅이나 문제 발견에 쓰는 용도는 앞으로 payment.status가 담당하여 책임을 분리하기로 했습니다.

## 🔍 테스트
- [ ] 테스트 코드 작성
- [ ] API 테스트
- [ ] 로컬 테스트

## 📸 스크린샷
// UI 변경사항이 있는 경우

## ✅ 체크리스트
- [x] main/develop 브랜치가 아닌 feature 브랜치에서 작성했나요?
- [x] 코딩 컨벤션을 준수했나요?
- [x] 불필요한 코드는 제거했나요?
- [x] 주석은 충분히 작성했나요?
- [ ] 테스트는 완료했나요?

## 🙋‍♂️ 리뷰어에게
// 리뷰어가 집중해서 봐야 하는 부분
// 리뷰어에게 요청하고 싶은 사항