### PR TITLE
[Feat] 미확정 Trade객체의 확정을 위한 대사 배치 스케줄러

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -79,6 +79,13 @@ dependencies {
     implementation("com.squareup.okhttp3:mockwebserver:4.12.0")
     testImplementation("com.squareup.okhttp3:mockwebserver:4.12.0")
 
+    // Spring Batch
+    implementation("org.springframework.boot:spring-boot-starter-batch")
+
+    // Spring Batch 테스트용
+    testImplementation ("org.springframework.batch:spring-batch-test")
+    testImplementation("com.squareup.okhttp3:mockwebserver:4.12.0")
+
 }
 
 tasks.withType<Test> {

--- a/src/main/java/com/windfall/api/payment/reconcilebatch/PaymentReconcileProcessor.java
+++ b/src/main/java/com/windfall/api/payment/reconcilebatch/PaymentReconcileProcessor.java
@@ -1,0 +1,80 @@
+package com.windfall.api.payment.reconcilebatch;
+
+import com.windfall.domain.payment.entity.Payment;
+import com.windfall.domain.payment.enums.PaymentStatus;
+import com.windfall.domain.payment.repository.PaymentRepository;
+import com.windfall.domain.trade.entity.Trade;
+import com.windfall.domain.trade.enums.TradeStatus;
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.batch.item.ItemProcessor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpHeaders;
+import org.springframework.stereotype.Component;
+import org.springframework.web.reactive.function.client.WebClient;
+
+// TODO: 배치 성공 처리 후 auction 완료 처리, 채팅방 생성도!
+@Slf4j
+@Component
+public class PaymentReconcileProcessor implements ItemProcessor<Trade, ReconcileCommand> {
+
+  private final PaymentRepository paymentRepository;
+  private final WebClient webClient;
+  private final String authorization;
+
+  public PaymentReconcileProcessor(
+      PaymentRepository paymentRepository,
+      WebClient webClient,
+      @Value("${spring.toss.secretkey}") String widgetSecretKey) {
+    this.paymentRepository = paymentRepository;
+    this.webClient = webClient;
+    this.authorization = "Basic " + Base64.getEncoder()
+        .encodeToString((widgetSecretKey + ":").getBytes(StandardCharsets.UTF_8));
+  }
+
+  @Override
+  public ReconcileCommand process(Trade trade) {
+
+    // 1. (tradeId, buyerId)로 가장 최근 payment 1건 조회
+    Payment payment = paymentRepository
+        .findTopByTradeIdAndBuyerIdOrderByIdDesc(trade.getId(), trade.getBuyerId())
+        .orElse(null);
+
+    if (payment == null || payment.getPaymentKey() == null) {
+      return null; // 대사할 payment 없음 → 패스
+    }
+
+    // 2. paymentKey(멱등성키)로 토스에 결제 상태 조회
+    TossPaymentInquiryResponse response;
+    try {
+      response = webClient.get()
+          .uri("/v1/payments/{paymentKey}", payment.getPaymentKey())
+          .header(HttpHeaders.AUTHORIZATION, authorization)
+          .retrieve()
+          .bodyToMono(TossPaymentInquiryResponse.class)
+          .block();
+    } catch (Exception e) {
+      log.warn("토스 결제 조회 실패. tradeId={}, paymentKey={}",
+          trade.getId(), payment.getPaymentKey(), e);
+      return null; // 이번엔 패스 → 다음 배치 때 자동 재시도
+    }
+
+    if (response == null || response.status() == null) {
+      return null;
+    }
+
+    // 3. 토스 상태 → 우리 상태 결정
+    return switch (response.status()) {
+      case "DONE" -> new ReconcileCommand(
+          trade.getId(), TradeStatus.PAYMENT_COMPLETED,
+          payment.getId(), PaymentStatus.DONE);
+
+      case "ABORTED", "EXPIRED" -> new ReconcileCommand(
+          trade.getId(), TradeStatus.PAYMENT_FAILED,
+          payment.getId(), PaymentStatus.FAILED);
+
+      default -> null; // READY, IN_PROGRESS 등 진행중 → 패스
+    };
+  }
+}

--- a/src/main/java/com/windfall/api/payment/reconcilebatch/PaymentReconcileScheduler.java
+++ b/src/main/java/com/windfall/api/payment/reconcilebatch/PaymentReconcileScheduler.java
@@ -1,0 +1,38 @@
+package com.windfall.api.payment.reconcilebatch;
+
+import java.time.LocalDateTime;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.batch.core.Job;
+import org.springframework.batch.core.JobParameters;
+import org.springframework.batch.core.JobParametersBuilder;
+import org.springframework.batch.core.launch.JobLauncher;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class PaymentReconcileScheduler {
+
+  private final JobLauncher jobLauncher;
+  private final Job paymentReconcileJob;
+
+  // 이전 실행이 '끝난 뒤' 5분 후 다시 실행
+  // @Scheduled(fixedDelay = 5 * 60 * 1000)
+  @Scheduled(fixedDelayString = "${payment.reconcile.fixed-delay:300000}")
+  public void runPaymentReconcileJob() {
+    try {
+      JobParameters jobParameters = new JobParametersBuilder()
+          // 스프링 배치는 "Job 이름 + JobParameters 조합"이 이미 성공한 실행이면 재실행하지 않음.
+          // → 매번 달라지는 현재 시각을 넣어 새 실행으로 인식시킴.
+          .addLocalDateTime("runAt", LocalDateTime.now())
+          .toJobParameters();
+
+      jobLauncher.run(paymentReconcileJob, jobParameters);
+    } catch (Exception e) {
+      log.error("결제 대사 배치 실행 실패", e);
+    }
+  }
+
+}

--- a/src/main/java/com/windfall/api/payment/reconcilebatch/PaymentReconcileWriter.java
+++ b/src/main/java/com/windfall/api/payment/reconcilebatch/PaymentReconcileWriter.java
@@ -1,0 +1,26 @@
+package com.windfall.api.payment.reconcilebatch;
+
+import com.windfall.domain.payment.repository.PaymentRepository;
+import com.windfall.domain.trade.repository.TradeRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.batch.item.Chunk;
+import org.springframework.batch.item.ItemWriter;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class PaymentReconcileWriter implements ItemWriter<ReconcileCommand> {
+
+  private final TradeRepository tradeRepository;
+  private final PaymentRepository paymentRepository;
+
+  @Override
+  public void write(Chunk<? extends ReconcileCommand> chunk) {
+    for (ReconcileCommand command : chunk) {
+      tradeRepository.updateStatus(command.tradeId(), command.tradeStatus());
+      paymentRepository.updateStatus(command.paymentId(), command.paymentStatus());
+    }
+  }
+}

--- a/src/main/java/com/windfall/api/payment/reconcilebatch/ProcessingTradeReader.java
+++ b/src/main/java/com/windfall/api/payment/reconcilebatch/ProcessingTradeReader.java
@@ -1,0 +1,23 @@
+package com.windfall.api.payment.reconcilebatch;
+
+import com.windfall.domain.trade.entity.Trade;
+import com.windfall.domain.trade.enums.TradeStatus;
+import jakarta.persistence.EntityManagerFactory;
+import java.util.Map;
+import org.springframework.batch.item.database.JpaCursorItemReader;
+import org.springframework.stereotype.Component;
+
+@Component
+public class ProcessingTradeReader extends JpaCursorItemReader<Trade> {
+
+  public ProcessingTradeReader(EntityManagerFactory entityManagerFactory) {
+    setName("processingTradeReader");
+    setEntityManagerFactory(entityManagerFactory);
+    setQueryString("""
+        SELECT t FROM Trade t
+        WHERE t.status = :status
+        ORDER BY t.id ASC
+        """);
+    setParameterValues(Map.of("status", TradeStatus.PROCESSING));
+  }
+}

--- a/src/main/java/com/windfall/api/payment/reconcilebatch/ReconcileCommand.java
+++ b/src/main/java/com/windfall/api/payment/reconcilebatch/ReconcileCommand.java
@@ -1,0 +1,12 @@
+package com.windfall.api.payment.reconcilebatch;
+
+import com.windfall.domain.payment.enums.PaymentStatus;
+import com.windfall.domain.trade.enums.TradeStatus;
+
+public record ReconcileCommand(
+    Long tradeId,
+    TradeStatus tradeStatus,
+    Long paymentId,
+    PaymentStatus paymentStatus
+) {
+}

--- a/src/main/java/com/windfall/api/payment/reconcilebatch/TossPaymentInquiryResponse.java
+++ b/src/main/java/com/windfall/api/payment/reconcilebatch/TossPaymentInquiryResponse.java
@@ -1,0 +1,10 @@
+package com.windfall.api.payment.reconcilebatch;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+public record TossPaymentInquiryResponse(
+    String paymentKey,
+    String status
+) {
+}

--- a/src/main/java/com/windfall/api/payment/service/PaymentPostProcessService.java
+++ b/src/main/java/com/windfall/api/payment/service/PaymentPostProcessService.java
@@ -4,12 +4,11 @@ import com.windfall.api.auction.service.AuctionStateService;
 import com.windfall.domain.chat.entity.ChatRoom;
 import com.windfall.domain.chat.repository.ChatRoomRepository;
 import com.windfall.domain.payment.entity.Payment;
-import com.windfall.domain.payment.entity.PaymentSelection;
-import com.windfall.domain.payment.enums.PaymentMethod;
-import com.windfall.domain.payment.enums.PaymentProvider;
+import com.windfall.domain.payment.enums.PaymentStatus;
 import com.windfall.domain.payment.repository.PaymentRepository;
 import com.windfall.domain.trade.entity.Trade;
 import com.windfall.domain.trade.enums.TradeStatus;
+import com.windfall.domain.trade.repository.TradeRepository;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -18,18 +17,21 @@ import org.springframework.transaction.annotation.Transactional;
 @Service
 public class PaymentPostProcessService {
 
-  AuctionStateService auctionStateService;
-  PaymentRepository paymentRepository;
-  ChatRoomRepository chatRoomRepository;
+  private final AuctionStateService auctionStateService;
+  private final PaymentRepository paymentRepository;
+  private final ChatRoomRepository chatRoomRepository;
+  private final TradeRepository tradeRepository;
 
   public PaymentPostProcessService(
       AuctionStateService auctionStateService,
       PaymentRepository paymentRepository,
-      ChatRoomRepository chatRoomRepository
+      ChatRoomRepository chatRoomRepository,
+      TradeRepository tradeRepository
   ) {
     this.auctionStateService = auctionStateService;
     this.paymentRepository = paymentRepository;
     this.chatRoomRepository = chatRoomRepository;
+    this.tradeRepository = tradeRepository;
   }
 
   @Transactional
@@ -41,11 +43,15 @@ public class PaymentPostProcessService {
 
     auctionStateService.completeAuction(auctionId);
 
-    trade.changeStatus(TradeStatus.PAYMENT_COMPLETED);
+    // trade.changeStatus → 벌크 UPDATE
+    tradeRepository.updateStatus(trade.getId(), TradeStatus.PAYMENT_COMPLETED);
 
-    Payment payment = Payment.confirm(trade.getId(), paymentKey, amount,
-        new PaymentSelection(PaymentProvider.TOSS, PaymentMethod.MOBILE_PAYMENT));
-    paymentRepository.save(payment);
+    // PaymentPreProcessService 때 생성한 payment의 상태를 갱신
+    Payment payment = paymentRepository.findByPaymentKey(paymentKey)
+        .orElseThrow(() -> new IllegalStateException(
+            "선점 시 생성됐어야 할 Payment 없음. paymentKey=" + paymentKey));
+    // 영속 상태 → 커밋 시 자동 UPDATE
+    payment.changeStatus(PaymentStatus.DONE);
 
     ChatRoom chatRoom = ChatRoom.generateChatRoom(trade);
     chatRoomRepository.save(chatRoom);

--- a/src/main/java/com/windfall/api/payment/service/PaymentPreProcessService.java
+++ b/src/main/java/com/windfall/api/payment/service/PaymentPreProcessService.java
@@ -3,6 +3,11 @@ package com.windfall.api.payment.service;
 import static com.windfall.global.exception.ErrorCode.PAYMENT_REQUEST_LATE;
 
 import com.windfall.domain.auction.entity.Auction;
+import com.windfall.domain.payment.entity.Payment;
+import com.windfall.domain.payment.entity.PaymentSelection;
+import com.windfall.domain.payment.enums.PaymentMethod;
+import com.windfall.domain.payment.enums.PaymentProvider;
+import com.windfall.domain.payment.repository.PaymentRepository;
 import com.windfall.domain.trade.entity.Trade;
 import com.windfall.domain.trade.enums.TradeStatus;
 import com.windfall.domain.trade.repository.TradeRepository;
@@ -20,15 +25,16 @@ import org.springframework.transaction.annotation.Transactional;
 public class PaymentPreProcessService {
 
   private final TradeRepository tradeRepository;
+  private final PaymentRepository paymentRepository;
 
   @Transactional
-  public Trade acquirePaymentRequestPermission(Auction auction, Long buyerId, Long amount) {
+  public Trade acquirePaymentRequestPermission(Auction auction, Long buyerId, Long amount, String paymentKey) {
 
     Trade existingTrade =
         tradeRepository.findByAuction(auction)
             .orElse(null);
 
-    // 최초로 trade 생성/UNIQUE로 trade 다수 생성 예방.
+    // 경로 1: 최초 선점 (trade 생성). 중복 생성 요청은 UNIQUE로 예방.
     if (existingTrade == null) {
 
       Trade newTrade = Trade.builder()
@@ -39,19 +45,24 @@ public class PaymentPreProcessService {
           .status(TradeStatus.PROCESSING)
           .build();
 
+      Trade savedTrade;
       try {
-
-        return tradeRepository.save(newTrade);
-
+        savedTrade = tradeRepository.save(newTrade);
       } catch (DataIntegrityViolationException e) {
         log.warn("[RACE] UNIQUE constraint blocked duplicate trade. auctionId={}", auction.getId());
         throw new ErrorException(PAYMENT_REQUEST_LATE);
       }
+
+      savePaymentInProgress(savedTrade, buyerId, amount, paymentKey);
+      return savedTrade;
     }
 
-    // 기존 trade가 결제 가능 상태라면, 결제 요청을 선점 시도(PROCESSING으로 상태 변경)
+    // 경로 2: 기존 trade가 결제 가능 상태라면,
+    // 결제 요청을 선점 시도(PROCESSING으로 상태 변경)
+    // 중복 요청은 원자적 UPDATE문으로 예방.
     int updated = tradeRepository.reservePaymentProcessing(
         auction,
+        buyerId,
         TradeStatus.PROCESSING,
         List.of(
             TradeStatus.PAYMENT_FAILED,
@@ -64,8 +75,18 @@ public class PaymentPreProcessService {
       throw new ErrorException(PAYMENT_REQUEST_LATE);
     }
 
+    Trade trade = tradeRepository.findByAuction(auction).orElseThrow();
+    savePaymentInProgress(trade, buyerId, amount, paymentKey);
+
     return tradeRepository.findByAuction(auction)
         .orElseThrow();
   }
 
+  private void savePaymentInProgress(Trade trade, Long buyerId, Long amount, String paymentKey) {
+    // TODO: PaymentMethod는 프론트에서 안 내려와 기존 코드처럼 임시 하드코딩 유지
+    Payment payment = Payment.request(
+        trade.getId(), buyerId, paymentKey, amount,
+        new PaymentSelection(PaymentProvider.TOSS, PaymentMethod.MOBILE_PAYMENT));
+    paymentRepository.save(payment);
+  }
 }

--- a/src/main/java/com/windfall/api/payment/service/PaymentService.java
+++ b/src/main/java/com/windfall/api/payment/service/PaymentService.java
@@ -64,7 +64,7 @@ public class PaymentService {
       throw new ErrorException(ErrorCode.NOT_FOUND_BUYER);
     }
 
-    Trade trade = paymentPreProcessService.acquirePaymentRequestPermission(auction, buyerId, amount);
+    Trade trade = paymentPreProcessService.acquirePaymentRequestPermission(auction, buyerId, amount, paymentKey);
     // 테스트용
     log.info(
         "Payment request claim success. auctionId={}, buyerId={}, tradeId={}",
@@ -150,10 +150,7 @@ public class PaymentService {
       } catch (ErrorException e) {
 
         // 마지막 시도라면 최종 실패
-        if (attempt == maxAttempts) {
-          tradeRepository.updateStatus(trade.getId(), TradeStatus.PAYMENT_FAILED);
-          throw e;
-        }
+        tradeRepository.updateStatus(trade.getId(), TradeStatus.PAYMENT_FAILED);
 
         // Full Jitter 대기
         long delay = backoffStrategy.nextDelay(attempt);

--- a/src/main/java/com/windfall/domain/payment/entity/Payment.java
+++ b/src/main/java/com/windfall/domain/payment/entity/Payment.java
@@ -5,6 +5,8 @@ import com.windfall.global.entity.BaseEntity;
 import jakarta.persistence.Column;
 import jakarta.persistence.Embedded;
 import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -22,6 +24,7 @@ public class Payment extends BaseEntity {
   @Column(nullable = true, unique = true)
   private String paymentKey;
 
+  @Enumerated(EnumType.STRING)
   @Column(nullable = false)
   private PaymentStatus status;
 
@@ -30,6 +33,9 @@ public class Payment extends BaseEntity {
 
   @Column(nullable = false)
   private Long tradeId;
+
+  @Column(nullable=false)
+  private Long buyerId;
 
   @Column(nullable = false)
   private Long price;
@@ -48,5 +54,22 @@ public class Payment extends BaseEntity {
         .status(PaymentStatus.DONE)
         .paymentSelection(selection)
         .build();
+  }
+
+  /** 선점 시점: '결제 진행 중' 상태로 생성 */
+  public static Payment request(
+      Long tradeId, Long buyerId, String paymentKey, Long price, PaymentSelection selection) {
+    return Payment.builder()
+        .tradeId(tradeId)
+        .buyerId(buyerId)
+        .paymentKey(paymentKey)
+        .price(price)
+        .status(PaymentStatus.IN_PROGRESS)
+        .paymentSelection(selection)
+        .build();
+  }
+
+  public void changeStatus(PaymentStatus status) {
+    this.status = status;
   }
 }

--- a/src/main/java/com/windfall/domain/payment/repository/PaymentRepository.java
+++ b/src/main/java/com/windfall/domain/payment/repository/PaymentRepository.java
@@ -1,8 +1,20 @@
 package com.windfall.domain.payment.repository;
 
 import com.windfall.domain.payment.entity.Payment;
+import com.windfall.domain.payment.enums.PaymentStatus;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface PaymentRepository extends JpaRepository<Payment, Long> {
+  Optional<Payment> findByPaymentKey(String paymentKey);
 
+  // OrderByIdDesc: 가장 최근 Trade 결제 1건만 잡기 위함.
+  Optional<Payment> findTopByTradeIdAndBuyerIdOrderByIdDesc(Long tradeId, Long buyerId);
+
+  @Modifying(clearAutomatically = true, flushAutomatically = true)
+  @Query("UPDATE Payment p SET p.status = :status WHERE p.id = :id")
+  int updateStatus(@Param("id") Long id, @Param("status") PaymentStatus status);
 }

--- a/src/main/java/com/windfall/domain/trade/repository/TradeRepository.java
+++ b/src/main/java/com/windfall/domain/trade/repository/TradeRepository.java
@@ -17,12 +17,14 @@ public interface TradeRepository extends JpaRepository<Trade, Long> {
   @Modifying(clearAutomatically = true, flushAutomatically = true)
   @Query("""
       UPDATE Trade t
-      SET t.status = :processingStatus
+      SET t.status = :processingStatus,
+        t.buyerId = :buyerId
       WHERE t.auction = :auction
         AND t.status IN :retryableStatuses
       """)
   int reservePaymentProcessing(
       @Param("auction") Auction auction,
+      @Param("buyerId") Long buyerId,
       @Param("processingStatus") TradeStatus processingStatus,
       @Param("retryableStatuses") List<TradeStatus> retryableStatuses
   );

--- a/src/main/java/com/windfall/global/config/paymentreconcile/PaymentReconcileJobConfig.java
+++ b/src/main/java/com/windfall/global/config/paymentreconcile/PaymentReconcileJobConfig.java
@@ -1,0 +1,19 @@
+package com.windfall.global.config.paymentreconcile;
+
+import org.springframework.batch.core.Job;
+import org.springframework.batch.core.Step;
+import org.springframework.batch.core.job.builder.JobBuilder;
+import org.springframework.batch.core.repository.JobRepository;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+// SpringBatch에서 Job과 Step은 @Bean 정의로 만듬. (클래스 상속 방식 X)
+@Configuration
+public class PaymentReconcileJobConfig {
+  @Bean
+  public Job paymentReconcileJob(JobRepository jobRepository, Step paymentReconcileStep) {
+    return new JobBuilder("paymentReconcileJob", jobRepository)
+        .start(paymentReconcileStep)
+        .build();
+  }
+}

--- a/src/main/java/com/windfall/global/config/paymentreconcile/PaymentReconcileSchedulerConfig.java
+++ b/src/main/java/com/windfall/global/config/paymentreconcile/PaymentReconcileSchedulerConfig.java
@@ -1,0 +1,5 @@
+package com.windfall.global.config.paymentreconcile;
+
+public class PaymentReconcileSchedulerConfig {
+
+}

--- a/src/main/java/com/windfall/global/config/paymentreconcile/PaymentReconcileStepConfig.java
+++ b/src/main/java/com/windfall/global/config/paymentreconcile/PaymentReconcileStepConfig.java
@@ -1,0 +1,35 @@
+package com.windfall.global.config.paymentreconcile;
+
+import com.windfall.api.payment.reconcilebatch.PaymentReconcileProcessor;
+import com.windfall.api.payment.reconcilebatch.PaymentReconcileWriter;
+import com.windfall.api.payment.reconcilebatch.ProcessingTradeReader;
+import com.windfall.api.payment.reconcilebatch.ReconcileCommand;
+import com.windfall.domain.trade.entity.Trade;
+import lombok.RequiredArgsConstructor;
+import org.springframework.batch.core.Step;
+import org.springframework.batch.core.repository.JobRepository;
+import org.springframework.batch.core.step.builder.StepBuilder;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.transaction.PlatformTransactionManager;
+
+@Configuration
+@RequiredArgsConstructor
+public class PaymentReconcileStepConfig {
+  private final ProcessingTradeReader reader;
+  private final PaymentReconcileProcessor processor;
+  private final PaymentReconcileWriter writer;
+
+  @Bean
+  public Step paymentReconcileStep(
+      JobRepository jobRepository,
+      PlatformTransactionManager transactionManager) {
+
+    return new StepBuilder("paymentReconcileStep", jobRepository)
+        .<Trade, ReconcileCommand>chunk(10, transactionManager)
+        .reader(reader)
+        .processor(processor)
+        .writer(writer)
+        .build();
+  }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -28,6 +28,12 @@ spring:
       ddl-auto: validate
     show-sql: true
 
+  batch:
+    job:
+      enabled: false # 앱 시작 시 배치 자동 실행 금지
+      jdbc:
+        initialize-schema: always # 배치 메타테이블 자동 생성. 실제 운영 시 never로 바꾸자.
+
   kakao:
     client:
       id: ${REST_API_KAKAO}

--- a/src/test/java/com/windfall/api/payment/integration/trade/AcquiringPermissionFromExistingTradeTest.java
+++ b/src/test/java/com/windfall/api/payment/integration/trade/AcquiringPermissionFromExistingTradeTest.java
@@ -76,11 +76,11 @@ public class AcquiringPermissionFromExistingTradeTest {
 
     // when
     Future<?> a = executor.submit(() ->
-        paymentPreProcessService.acquirePaymentRequestPermission(auction, 3L, 1000L)
+        paymentPreProcessService.acquirePaymentRequestPermission(auction, 3L, 1000L, "pk-a")
     );
 
     Future<?> b = executor.submit(() ->
-        paymentPreProcessService.acquirePaymentRequestPermission(auction, 2L, 2000L)
+        paymentPreProcessService.acquirePaymentRequestPermission(auction, 2L, 2000L, "pk-a")
     );
 
     Exception exA = null;

--- a/src/test/java/com/windfall/api/payment/integration/trade/TradeCreationUniqueConstraintTest.java
+++ b/src/test/java/com/windfall/api/payment/integration/trade/TradeCreationUniqueConstraintTest.java
@@ -72,11 +72,11 @@ public class TradeCreationUniqueConstraintTest {
 
     // when
     Future<?> a = executor.submit(() ->
-        paymentPreProcessService.acquirePaymentRequestPermission(auction, 1L, 1000L)
+        paymentPreProcessService.acquirePaymentRequestPermission(auction, 1L, 1000L, "pk-a")
     );
 
     Future<?> b = executor.submit(() ->
-        paymentPreProcessService.acquirePaymentRequestPermission(auction, 2L, 2000L)
+        paymentPreProcessService.acquirePaymentRequestPermission(auction, 2L, 2000L, "pk-b")
     );
 
     Exception exA = null;

--- a/src/test/java/com/windfall/api/payment/reconcilebatch/PaymentReconcileJobTest.java
+++ b/src/test/java/com/windfall/api/payment/reconcilebatch/PaymentReconcileJobTest.java
@@ -1,0 +1,221 @@
+package com.windfall.api.payment.reconcilebatch;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import com.windfall.api.auction.dto.request.AuctionCreateRequest;
+import com.windfall.domain.auction.entity.Auction;
+import com.windfall.domain.auction.enums.AuctionCategory;
+import com.windfall.domain.auction.repository.AuctionRepository;
+import com.windfall.domain.payment.entity.Payment;
+import com.windfall.domain.payment.entity.PaymentSelection;
+import com.windfall.domain.payment.enums.PaymentMethod;
+import com.windfall.domain.payment.enums.PaymentProvider;
+import com.windfall.domain.payment.enums.PaymentStatus;
+import com.windfall.domain.payment.repository.PaymentRepository;
+import com.windfall.domain.trade.entity.Trade;
+import com.windfall.domain.trade.enums.TradeStatus;
+import com.windfall.domain.trade.repository.TradeRepository;
+import com.windfall.domain.user.entity.User;
+import com.windfall.domain.user.enums.ProviderType;
+import com.windfall.domain.user.repository.UserRepository;
+import com.windfall.global.config.BatchTestConfig;
+import com.windfall.global.config.MockTossConfig;
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.UUID;
+import okhttp3.mockwebserver.MockResponse;
+import okhttp3.mockwebserver.MockWebServer;
+import okhttp3.mockwebserver.QueueDispatcher;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.batch.core.BatchStatus;
+import org.springframework.batch.core.JobExecution;
+import org.springframework.batch.core.JobParametersBuilder;
+import org.springframework.batch.core.StepExecution;
+import org.springframework.batch.test.JobLauncherTestUtils;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.TestPropertySource;
+
+@SpringBootTest
+@Import({MockTossConfig.class, BatchTestConfig.class})
+@TestPropertySource(properties = "payment.reconcile.fixed-delay=99999999")
+class PaymentReconcileJobTest {
+
+  @Autowired JobLauncherTestUtils jobLauncherTestUtils;
+  @Autowired MockWebServer mockTossServer;
+  @Autowired TradeRepository tradeRepository;
+  @Autowired PaymentRepository paymentRepository;
+  @Autowired AuctionRepository auctionRepository;
+  @Autowired UserRepository userRepository;
+
+  private static final Long BUYER_ID = 2L;
+
+  private Auction auction;
+  private int tossCallsBefore;
+
+  @BeforeEach
+  void setUp() {
+    paymentRepository.deleteAll();
+    tradeRepository.deleteAll();
+
+    // 큐에 남은 이전 테스트의 응답 제거
+    mockTossServer.setDispatcher(new QueueDispatcher());
+
+    // providerId가 UNIQUE라면 매번 같은 값은 충돌 → 랜덤
+    User seller = userRepository.save(new User(
+        ProviderType.KAKAO, UUID.randomUUID().toString(), "email", "nickname", "imgUrl"));
+
+    AuctionCreateRequest request = new AuctionCreateRequest("title", "description",
+        AuctionCategory.CLOTHING, new ArrayList<>(), new ArrayList<>(),
+        1L, 1L, 1L, LocalDateTime.now());
+    auction = auctionRepository.save(Auction.create(request, seller));
+    tossCallsBefore = mockTossServer.getRequestCount();
+  }
+
+  private int tossCallsInThisTest() {
+    return mockTossServer.getRequestCount() - tossCallsBefore;
+  }
+
+  // ---------- 시나리오 ----------
+
+  // ---------- 1. 상태변경 제대로 되나? -----------
+  @Test
+  void when_toss_is_in_progress_then_do_not_change_status() throws Exception {
+    Long tradeId = givenProcessingTradeWithPayment("pk-1");
+    enqueueToss("{\"paymentKey\":\"pk-1\",\"status\":\"IN_PROGRESS\"}");
+
+    StepExecution step = launchAndGetStep();
+
+    assertCounts(step, 1, 1, 0);
+    assertEquals(TradeStatus.PROCESSING, findTrade(tradeId).getStatus());
+    assertEquals(PaymentStatus.IN_PROGRESS, findPayment("pk-1").getStatus());
+  }
+
+  @Test
+  void when_toss_is_done_then_mark_completed() throws Exception {
+    Long tradeId = givenProcessingTradeWithPayment("pk-2");
+    enqueueToss("{\"paymentKey\":\"pk-2\",\"status\":\"DONE\"}");
+
+    StepExecution step = launchAndGetStep();
+
+    assertCounts(step, 1, 0, 1);
+    assertEquals(TradeStatus.PAYMENT_COMPLETED, findTrade(tradeId).getStatus());
+    assertEquals(PaymentStatus.DONE, findPayment("pk-2").getStatus());
+  }
+
+  @Test
+  void when_toss_is_aborted_then_mark_failed() throws Exception {
+    Long tradeId = givenProcessingTradeWithPayment("pk-3");
+    enqueueToss("{\"paymentKey\":\"pk-3\",\"status\":\"ABORTED\"}");
+
+    StepExecution step = launchAndGetStep();
+
+    assertCounts(step, 1, 0, 1);
+    assertEquals(TradeStatus.PAYMENT_FAILED, findTrade(tradeId).getStatus());
+    assertEquals(PaymentStatus.FAILED, findPayment("pk-3").getStatus());
+  }
+
+  // ---------- 2. 혹시 중간에 외부 통신 실패해도 나머지를 처리할 내구성이 있나? -----------
+  @Test
+  void when_pg_returns_error_then_batch_survives_and_status_unchanged() throws Exception {
+    Long tradeId = givenProcessingTradeWithPayment("pk-4");
+    mockTossServer.enqueue(new MockResponse().setResponseCode(500));
+
+    JobExecution execution = launchJob();
+    StepExecution step = firstStep(execution);
+
+    assertEquals(BatchStatus.COMPLETED, execution.getStatus());  // 배치가 죽지 않음
+    assertCounts(step, 1, 1, 0);
+    assertEquals(TradeStatus.PROCESSING, findTrade(tradeId).getStatus());
+    assertEquals(PaymentStatus.IN_PROGRESS, findPayment("pk-4").getStatus());
+  }
+
+  // ---------- 2. paymentKey를 위해 payment 객체 부르는데에 실패해도 나머지를 처리할 내구서이 있나? -----------
+  @Test
+  void when_payment_not_exists_then_pass() throws Exception {
+    Long tradeId = givenProcessingTrade();   // payment 저장 안 함
+
+    StepExecution step = launchAndGetStep();
+
+    assertCounts(step, 1, 1, 0);
+    assertEquals(0, tossCallsInThisTest());   // payment 없으면 토스 호출조차 없음
+    assertEquals(TradeStatus.PROCESSING, findTrade(tradeId).getStatus());
+  }
+
+  // ---------- 3. 멱등성을 보장하나? -----------
+  @Test
+  void when_run_twice_then_second_run_writes_nothing() throws Exception {
+    Long tradeId = givenProcessingTradeWithPayment("pk-6");
+    enqueueToss("{\"paymentKey\":\"pk-6\",\"status\":\"DONE\"}");
+
+    StepExecution first = launchAndGetStep();
+    assertCounts(first, 1, 0, 1);
+    assertEquals(TradeStatus.PAYMENT_COMPLETED, findTrade(tradeId).getStatus());
+
+    StepExecution second = launchAndGetStep();   // 응답 추가 enqueue 없음
+
+    assertCounts(second, 0, 0, 0);
+    assertEquals(1, tossCallsInThisTest());   // 2회차엔 재조회 없음
+    assertEquals(TradeStatus.PAYMENT_COMPLETED, findTrade(tradeId).getStatus());
+    assertEquals(PaymentStatus.DONE, findPayment("pk-6").getStatus());
+  }
+
+  // ---------- helper ----------
+
+  private Long givenProcessingTrade() {
+    Trade trade = tradeRepository.save(Trade.builder()
+        .auction(auction)
+        .buyerId(BUYER_ID)
+        .sellerId(auction.getSeller().getId())
+        .finalPrice(1000L)
+        .status(TradeStatus.PROCESSING)
+        .build());
+    return trade.getId();
+  }
+
+  private Long givenProcessingTradeWithPayment(String paymentKey) {
+    Long tradeId = givenProcessingTrade();
+    paymentRepository.save(Payment.request(
+        tradeId, BUYER_ID, paymentKey, 1000L,
+        new PaymentSelection(PaymentProvider.TOSS, PaymentMethod.MOBILE_PAYMENT)));
+    return tradeId;
+  }
+
+  private void enqueueToss(String json) {
+    mockTossServer.enqueue(new MockResponse()
+        .setBody(json)
+        .addHeader("Content-Type", "application/json"));
+  }
+
+  private JobExecution launchJob() throws Exception {
+    return jobLauncherTestUtils.launchJob(new JobParametersBuilder()
+        .addLong("runAt", System.nanoTime())   // 매 실행 고유값
+        .toJobParameters());
+  }
+
+  private StepExecution launchAndGetStep() throws Exception {
+    return firstStep(launchJob());
+  }
+
+  private StepExecution firstStep(JobExecution execution) {
+    return execution.getStepExecutions().iterator().next();
+  }
+
+  /** read == filter + write (누락 0) 까지 함께 검증 */
+  private void assertCounts(StepExecution step, long read, long filter, long write) {
+    assertEquals(read, step.getReadCount());
+    assertEquals(filter, step.getFilterCount());
+    assertEquals(write, step.getWriteCount());
+    assertEquals(step.getReadCount(), step.getFilterCount() + step.getWriteCount());
+  }
+
+  private Trade findTrade(Long id) {
+    return tradeRepository.findById(id).orElseThrow();
+  }
+
+  private Payment findPayment(String paymentKey) {
+    return paymentRepository.findByPaymentKey(paymentKey).orElseThrow();
+  }
+}

--- a/src/test/java/com/windfall/global/config/BatchTestConfig.java
+++ b/src/test/java/com/windfall/global/config/BatchTestConfig.java
@@ -1,0 +1,22 @@
+package com.windfall.global.config;
+
+
+import org.springframework.batch.core.Job;
+import org.springframework.batch.core.launch.JobLauncher;
+import org.springframework.batch.test.JobLauncherTestUtils;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+
+@TestConfiguration
+public class BatchTestConfig {
+
+  @Bean
+  public JobLauncherTestUtils jobLauncherTestUtils(
+      Job paymentReconcileJob, JobLauncher jobLauncher) {
+
+    JobLauncherTestUtils utils = new JobLauncherTestUtils();
+    utils.setJob(paymentReconcileJob);
+    utils.setJobLauncher(jobLauncher);
+    return utils;
+  }
+}

--- a/src/test/java/com/windfall/global/config/MockTossConfig.java
+++ b/src/test/java/com/windfall/global/config/MockTossConfig.java
@@ -1,0 +1,27 @@
+package com.windfall.global.config;
+
+import java.io.IOException;
+import okhttp3.mockwebserver.MockWebServer;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Primary;
+import org.springframework.web.reactive.function.client.WebClient;
+
+@TestConfiguration
+public class MockTossConfig {
+
+  @Bean
+  public MockWebServer mockTossServer() throws IOException {
+    MockWebServer server = new MockWebServer();
+    server.start();
+    return server;
+  }
+
+  @Bean
+  @Primary
+  public WebClient mockTossWebClient(MockWebServer mockTossServer) {
+    return WebClient.builder()
+        .baseUrl(mockTossServer.url("/").toString())
+        .build();
+  }
+}


### PR DESCRIPTION
- 배치 관련 config(global/config/paymentreconcile/)
- 배치 관련 코드(api/payment/reconcilebatch/)
- 배치를 위한 repository 변경 (PaymentRepository,TradeRepository)
- 배치를 위한 entity 변경 (Trade)
- 배치코드에 영향 받은 service(PaymentService, PaymentPreProcessService, PaymentPostProcessService)
- 배치 관련 테스트 코드 (test/../api/payment/reconcilebatch/)

## 📌 관련 이슈
- close #35 

## 📝 변경 사항
### AS-IS
- 서버 다운이나 장애 시 trade.status == PROCESSING인 객체는 영원히 미확정 개체로 남는 문제
- 만약 PG사 api 성공 후인데 이렇다면 정합성 문제 발생 (구매자는 돈이 빠져나갔지만, 판매자는 물건이 판매되었단 알림을 우리 서비스에서 못 받습니다.)

### TO-BE
- 스프링 배치를 쓴 스케줄러로 정기적으로 미확정 개체를 불러와서 PG사에 결제 결과 조회 -> SUCCESS, FAILED로 변경.
- PG사에서 아직 결제 진행중이라고 반환한 경우에만 패스합니다.
- 코드가 길어져서 아래와 같은 추후 구현점 기대.
- 1. 배치 스케줄러에서 구매 성공 확인 후 구매자-판매자 채팅방 객체도 생성해줘야합니다.
- 2. 배치 스케줄러에서 구매 성공 확인 후 옥션 성공 처리도 해줘야합니다. (일단은 없어도 금전 피해는 없음)
- 3. 현재 처리 건수가 수십건을 예상해서 for문 없이 1 trade 객체씩 불러옵니다. (N+1문제 예상). 추후 처리 건수 늘어나면 batch의 processor 코드 변경 기대.

## 🔍 테스트
- [x] 테스트 코드 작성
- [ ] API 테스트
- [x] 로컬 테스트

## 📸 스크린샷
// UI 변경사항이 있는 경우

## ✅ 체크리스트
- [x] main/develop 브랜치가 아닌 feature 브랜치에서 작성했나요?
- [x] 코딩 컨벤션을 준수했나요?
- [x] 불필요한 코드는 제거했나요?
- [x] 주석은 충분히 작성했나요?
- [x] 테스트는 완료했나요?

## 🙋‍♂️ 리뷰어에게
// 리뷰어가 집중해서 봐야 하는 부분
// 리뷰어에게 요청하고 싶은 사항